### PR TITLE
fix: make marked an optional peerdep

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -2,6 +2,18 @@
 
 `markdown` allows you to process markdown into HTML and render the result.
 
+**IMPORTANT:**
+
+In order to use `markdown`, you must install
+[marked](https://github.com/markedjs/marked) as a dependency in your project:
+
+```sh
+npm i -S marked
+```
+
+Additionally, if you use TypeScript, you should install the `@types/marked`
+package so you can get the correct types for `options.markedOptions`.
+
 ## Usage
 
 ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,10 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/marked": "^4.0.8",
-        "marked": "^4.2.12",
         "tslib": "^2.4.1"
       },
       "devDependencies": {
+        "@types/marked": "^4.0.8",
         "@types/mocha": "^10.0.1",
         "@typescript-eslint/eslint-plugin": "^5.47.1",
         "@typescript-eslint/parser": "^5.47.1",
@@ -23,13 +22,24 @@
         "eslint": "^8.30.0",
         "eslint-config-google": "^0.14.0",
         "lit": "^2.5.0",
+        "marked": "^4.2.12",
         "prettier": "^2.8.1",
         "rimraf": "^4.1.2",
         "typescript": "^4.9.4",
         "uvu": "^0.5.6"
       },
       "peerDependencies": {
-        "lit": "^2.5.0"
+        "@types/marked": "^4.0.8",
+        "lit": "^2.5.0",
+        "marked": "^4.2.12"
+      },
+      "peerDependenciesMeta": {
+        "@types/marked": {
+          "optional": true
+        },
+        "marked": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -513,7 +523,8 @@
     "node_modules/@types/marked": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.8.tgz",
-      "integrity": "sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw=="
+      "integrity": "sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -3562,6 +3573,7 @@
       "version": "4.2.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
       "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "dev": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5608,7 +5620,8 @@
     "@types/marked": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.8.tgz",
-      "integrity": "sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw=="
+      "integrity": "sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw==",
+      "dev": true
     },
     "@types/mime": {
       "version": "3.0.1",
@@ -7793,7 +7806,8 @@
     "marked": {
       "version": "4.2.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw=="
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "dev": true
     },
     "marky": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/43081j/relit#readme",
   "devDependencies": {
+    "@types/marked": "^4.0.8",
     "@types/mocha": "^10.0.1",
     "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.47.1",
@@ -37,17 +38,26 @@
     "eslint": "^8.30.0",
     "eslint-config-google": "^0.14.0",
     "lit": "^2.5.0",
+    "marked": "^4.2.12",
     "prettier": "^2.8.1",
     "rimraf": "^4.1.2",
     "typescript": "^4.9.4",
     "uvu": "^0.5.6"
   },
   "peerDependencies": {
-    "lit": "^2.5.0"
+    "@types/marked": "^4.0.8",
+    "lit": "^2.5.0",
+    "marked": "^4.2.12"
+  },
+  "peerDependenciesMeta": {
+    "marked": {
+      "optional": true
+    },
+    "@types/marked": {
+      "optional": true
+    }
   },
   "dependencies": {
-    "@types/marked": "^4.0.8",
-    "marked": "^4.2.12",
     "tslib": "^2.4.1"
   }
 }


### PR DESCRIPTION
Otherwise we unnecessarily install it even when we don't use `MarkdownController`