### PR TITLE
feat (bindInput): new input binding directive

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,8 @@
     {
       "files": ["src/test/**/*.ts"],
       "rules": {
-        "@typescript-eslint/no-non-null-assertion": "off"
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "no-prototype-builtins": "off"
       }
     }
   ]

--- a/docs/bindInput.md
+++ b/docs/bindInput.md
@@ -1,0 +1,75 @@
+# bindInput
+
+`bindInput` allows you to automatically bind a form input/control to a given
+property (i.e. two-way binding).
+
+## Usage
+
+```ts
+class MyElement extends LitElement {
+  @property({type: String})
+  public name: string = 'Bob';
+
+  render() {
+    return html`
+      <label>
+        Name:
+        <input type="text" ${bindInput(this, 'name')}>
+      </label>
+    `;
+  }
+}
+```
+
+This will automatically two-way bind the `input` element and the `name`
+property.
+
+The parameters (`bindInput(host, property)`) are as follows:
+
+- `host` - any object which has the specified `property`
+- `property` - the name of the property on `host` to bind
+
+## Supported elements
+
+The following elements are supported by this directive:
+
+- `input`
+- `select`
+- `textarea`
+- Compatible elements
+
+### Events
+
+By default, we listen for the `change` event and the `input` event.
+
+### `<input type="checkbox">`
+
+Checkbox inputs will result in a boolean value:
+
+```ts
+  return html`
+    <input type="checkbox" ${bindInput(this, 'isEnabled')}>
+  `;
+```
+
+In this example, `this.isEnabled` will be `true` or `false` depending on the
+checked state of the input.
+
+### `<select>`
+
+Select element bindings differ depending on if the select is `multiple` or not.
+
+With `<select multiple>`, the value will be an array of the selected values.
+
+With a regular `<select>`, the value will be the selected value.
+
+### Compatible elements
+
+Any element which implements the following will be supported:
+
+- Emits `change` events and/or `input` events
+- Has a `value` property
+
+## Options
+
+N/A

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 The following is the full list of available utilities:
 
 - [activeElement](./activeElement.md) - observable [document.activeElement](https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement)
+- [bindInput](./bindInput.md) - two-way bindings of form controls/inputs
 - [documentVisibility](./documentVisibility.md) - observable [document.visibilityState](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState)
 - [elementSize](./elementSize.md) - element width and height
 - [elementVisibility](./elementVisibility.md) - element visibility

--- a/src/directives/bindInput.ts
+++ b/src/directives/bindInput.ts
@@ -1,0 +1,305 @@
+import {directive, AsyncDirective} from 'lit/async-directive.js';
+import {nothing} from 'lit';
+import type {
+  ElementPart,
+  DirectiveParameters,
+  PartInfo,
+  DirectiveResult,
+  DirectiveClass
+} from 'lit/directive.js';
+import {PartType} from 'lit/directive.js';
+
+type PropertyLike = string | symbol | number;
+
+/**
+ * Determines if a target is an element
+ * @param {EventTarget} target Target to test
+ * @return {boolean}
+ */
+function isElement(target: EventTarget): target is Element {
+  return (target as Node).nodeType === Node.ELEMENT_NODE;
+}
+
+/**
+ * Determines if a target is an input element
+ * @param {EventTarget} target Target to test
+ * @return {boolean}
+ */
+function isInputElement(target: EventTarget): target is HTMLInputElement {
+  return isElement(target) && target.nodeName === 'INPUT';
+}
+
+/**
+ * Determines if a target is a select element
+ * @param {EventTarget} target Target to test
+ * @return {boolean}
+ */
+function isSelectElement(target: EventTarget): target is HTMLSelectElement {
+  return isElement(target) && target.nodeName === 'SELECT';
+}
+
+/**
+ * Determines if a target is a textarea element
+ * @param {EventTarget} target Target to test
+ * @return {boolean}
+ */
+function isTextAreaElement(target: EventTarget): target is HTMLTextAreaElement {
+  return isElement(target) && target.nodeName === 'TEXTAREA';
+}
+
+/**
+ * Tracks the value of a form control and propagates data two-way to/from a
+ * given host property.
+ */
+class BindInputDirective extends AsyncDirective {
+  private __element?: Element;
+  private __prop?: PropertyLike;
+  private __host: unknown | undefined = undefined;
+  private __lastValue: unknown = undefined;
+
+  /** @inheritdoc */
+  public constructor(partInfo: PartInfo) {
+    super(partInfo);
+
+    if (partInfo.type !== PartType.ELEMENT) {
+      throw new Error(
+        'The `bindInput` directive must be used in an element binding'
+      );
+    }
+  }
+
+  /** @inheritdoc */
+  public render(_host: unknown, _prop: PropertyLike): typeof nothing {
+    return nothing;
+  }
+
+  /** @inheritdoc */
+  public override update(
+    part: ElementPart,
+    [host, prop]: DirectiveParameters<this>
+  ): void {
+    if (part.element !== this.__element) {
+      this.__setElement(part.element);
+    }
+
+    if (prop !== this.__prop) {
+      this.__prop = prop;
+    }
+
+    if (host !== this.__host) {
+      this.__host = host;
+    }
+
+    if (host) {
+      this.__updateValueFromHost(host);
+    }
+  }
+
+  /**
+   * Updates the value based on the host's current value for the given
+   * property
+   * @param {unknown} host Host to retrieve value from
+   * @return {void}
+   */
+  private __updateValueFromHost(host: unknown): void {
+    if (
+      !this.__prop ||
+      !host ||
+      typeof host !== 'object' ||
+      !(this.__prop in host) ||
+      !this.__element
+    ) {
+      return;
+    }
+
+    const value = (host as Record<PropertyLike, unknown>)[this.__prop];
+    const element = this.__element;
+
+    if (value === this.__lastValue) {
+      return;
+    }
+
+    this.__lastValue = value;
+
+    if (isInputElement(element)) {
+      if (element.type === 'checkbox') {
+        element.checked = value === true;
+      } else {
+        element.value = String(value);
+      }
+    } else if (isSelectElement(element)) {
+      if (element.multiple) {
+        const valuesArray = Array.isArray(value) ? value : [value];
+
+        for (const opt of element.options) {
+          if (valuesArray.includes(opt.value)) {
+            opt.selected = true;
+          }
+        }
+      } else {
+        element.value = String(value);
+      }
+    } else if (isTextAreaElement(element)) {
+      element.value = String(value);
+    } else if ('value' in element) {
+      element.value = value;
+    }
+  }
+
+  /**
+   * Sets the element and its handlers
+   * @param {Element} element Element to set
+   * @return {void}
+   */
+  private __setElement(element: Element): void {
+    if (this.__element) {
+      this.__removeListenersFromElement(element);
+    }
+
+    this.__element = element;
+
+    this.__addListenersToElement(element);
+  }
+
+  /**
+   * Removes any associated listeners from the given element
+   * @param {Element} element Element to remove listeners from
+   * @return {void}
+   */
+  private __removeListenersFromElement(element: Element): void {
+    element.removeEventListener('change', this.__onChange);
+    element.removeEventListener('input', this.__onInput);
+  }
+
+  /**
+   * Adds any associated listeners to the given element
+   * @param {Element} element Element to add listeners to
+   * @return {void}
+   */
+  private __addListenersToElement(element: Element): void {
+    element.addEventListener('change', this.__onChange);
+    element.addEventListener('input', this.__onInput);
+  }
+
+  /**
+   * Fired when the change event occurs
+   * @param {Event} ev Event fired
+   * @return {void}
+   */
+  private __onChange = (ev: Event): void => {
+    const target = ev.currentTarget;
+
+    if (target !== this.__element) {
+      return;
+    }
+
+    this.__updateValueFromElement(this.__element);
+  };
+
+  /**
+   * Retrieves the value of a given element
+   * @param {Element} element Element to retrieve value from
+   * @return {unknown}
+   */
+  private __getValueFromElement(element: Element): unknown {
+    let value: unknown = undefined;
+
+    if (isInputElement(element)) {
+      if (element.type === 'checkbox') {
+        value = element.checked === true;
+      } else {
+        value = element.value;
+      }
+    } else if (isSelectElement(element)) {
+      if (element.multiple) {
+        value = [...element.selectedOptions].map((opt) => opt.value);
+      } else {
+        value = element.value;
+      }
+    } else if (isTextAreaElement(element)) {
+      value = element.value;
+    } else if ('value' in element) {
+      value = element.value;
+    }
+
+    return value;
+  }
+
+  /**
+   * Updates the host value from an element
+   * @param {Element} element Element to retrieve value from
+   * @return {void}
+   */
+  private __updateValueFromElement(element: Element): void {
+    if (!this.__prop) {
+      return;
+    }
+
+    if (
+      !this.__host ||
+      typeof this.__host !== 'object' ||
+      !(this.__prop in this.__host)
+    ) {
+      return;
+    }
+
+    const value = this.__getValueFromElement(element);
+
+    this.__lastValue = value;
+
+    (this.__host as Record<PropertyLike, unknown>)[this.__prop] = value;
+  }
+
+  /**
+   * Fired when the input event occurs
+   * @param {Event} ev Event fired
+   * @return {void}
+   */
+  private __onInput = (ev: Event): void => {
+    const target = ev.currentTarget;
+
+    if (target !== this.__element) {
+      return;
+    }
+
+    this.__updateValueFromElement(this.__element);
+  };
+
+  /** @inheritdoc */
+  public override reconnected(): void {
+    if (this.__element) {
+      this.__addListenersToElement(this.__element);
+    }
+  }
+
+  /** @inheritdoc */
+  public override disconnected(): void {
+    if (this.__element) {
+      this.__removeListenersFromElement(this.__element);
+    }
+  }
+}
+
+const bindInputDirective = directive(BindInputDirective);
+
+/**
+ * Two-way binds a given property to the input it is defined on.
+ *
+ * For example:
+ *
+ * ```ts
+ * html`
+ *  <input type="text" ${input(this, 'name')}>
+ * `;
+ * ```
+ *
+ * @param {T} host Host object of the property
+ * @param {string} key Property to bind
+ * @return {DirectiveResult}
+ */
+export function bindInput<T, TKey extends keyof T>(
+  host: T,
+  key: TKey
+): DirectiveResult<DirectiveClass> {
+  return bindInputDirective(host, key);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,3 +11,4 @@ export * from './controllers/permissions.js';
 export * from './controllers/propertyHistory.js';
 export * from './controllers/sessionStorage.js';
 export * from './controllers/windowScroll.js';
+export * from './directives/bindInput.js';

--- a/src/test/directives/bindInput_test.ts
+++ b/src/test/directives/bindInput_test.ts
@@ -1,0 +1,249 @@
+import {html, PropertyDeclarations} from 'lit';
+import * as assert from 'uvu/assert';
+import {bindInput} from '../../main.js';
+import {TestElementBase} from '../util.js';
+
+/**
+ * Test element for the input directive
+ */
+class BindInputDirectiveTest extends TestElementBase {
+  public prop?: unknown;
+
+  /** @inheritdoc */
+  public static override get properties(): PropertyDeclarations {
+    return {
+      prop: {type: Object}
+    };
+  }
+}
+
+customElements.define('bind-input-directive-test', BindInputDirectiveTest);
+
+suite('bindInput directive', () => {
+  let element: BindInputDirectiveTest;
+
+  setup(async () => {
+    element = document.createElement(
+      'bind-input-directive-test'
+    ) as BindInputDirectiveTest;
+    document.body.appendChild(element);
+  });
+
+  teardown(() => {
+    element.remove();
+  });
+
+  test('throws on non-element binding', async () => {
+    try {
+      element.template = () => html`
+        <div>${bindInput(element, 'prop')}</div>
+      `;
+      await element.updateComplete;
+      assert.unreachable();
+    } catch (err) {
+      assert.is(
+        (err as Error).message,
+        'The `bindInput` directive must be used in an element binding'
+      );
+    }
+  });
+
+  test('does nothing for non-existent properties', async () => {
+    element.template = () => html`
+      <input ${bindInput(element, 'nonsense' as keyof BindInputDirectiveTest)}>
+    `;
+    await element.updateComplete;
+
+    const node = element.shadowRoot!.querySelector('input')!;
+
+    assert.is(node.value, '');
+    assert.is(element.prop, undefined);
+  });
+
+  test('does nothing for non-existent properties (upwards)', async () => {
+    element.template = () => html`
+      <input ${bindInput(element, 'nonsense' as keyof BindInputDirectiveTest)}>
+    `;
+    await element.updateComplete;
+
+    const node = element.shadowRoot!.querySelector('input')!;
+
+    node.value = 'foo';
+    node.dispatchEvent(new Event('input'));
+    await element.updateComplete;
+
+    assert.is(element.prop, undefined);
+    assert.is(element.hasOwnProperty('nonsense'), false);
+  });
+
+  test('survives DOM reconnect', async () => {
+    element.template = () => html`
+      <input ${bindInput(element, 'prop')}>
+    `;
+    await element.updateComplete;
+
+    const inputNode = element.shadowRoot!.querySelector('input')!;
+    element.remove();
+
+    inputNode.value = 'xyz';
+    inputNode.dispatchEvent(new Event('input'));
+
+    assert.is(element.prop, undefined);
+
+    document.body.appendChild(element);
+
+    inputNode.value = 'xyz';
+    inputNode.dispatchEvent(new Event('input'));
+
+    assert.is(element.prop, 'xyz');
+  });
+
+  suite('<input>', () => {
+    setup(async () => {
+      element.template = () => html`
+        <input ${bindInput(element, 'prop')}>
+      `;
+      await element.updateComplete;
+    });
+
+    test('propagates value downwards', async () => {
+      element.prop = 'xyz';
+      await element.updateComplete;
+
+      const inputNode = element.shadowRoot!.querySelector('input')!;
+
+      assert.is(inputNode.value, 'xyz');
+    });
+
+    test('propagates value upwards', async () => {
+      const inputNode = element.shadowRoot!.querySelector('input')!;
+
+      inputNode.value = 'xyz';
+      inputNode.dispatchEvent(new Event('input'));
+      await element.updateComplete;
+
+      assert.is(element.prop, 'xyz');
+    });
+  });
+
+  suite('<input type="checkbox">', () => {
+    setup(async () => {
+      element.template = () => html`
+        <input ${bindInput(element, 'prop')} type="checkbox">
+      `;
+      await element.updateComplete;
+    });
+
+    test('propagates value downwards', async () => {
+      element.prop = true;
+      await element.updateComplete;
+
+      const node = element.shadowRoot!.querySelector('input')!;
+
+      assert.is(node.checked, true);
+    });
+
+    test('propagates value upwards', async () => {
+      const node = element.shadowRoot!.querySelector('input')!;
+
+      node.checked = true;
+      node.dispatchEvent(new Event('change'));
+      await element.updateComplete;
+
+      assert.is(element.prop, true);
+    });
+  });
+
+  suite('<select>', () => {
+    setup(async () => {
+      element.template = () => html`
+        <select ${bindInput(element, 'prop')}>
+          <option>xyz</option>
+        </select>
+      `;
+      await element.updateComplete;
+    });
+
+    test('propagates value downwards', async () => {
+      element.prop = 'xyz';
+      await element.updateComplete;
+
+      const node = element.shadowRoot!.querySelector('select')!;
+
+      assert.is(node.value, 'xyz');
+    });
+
+    test('propagates value upwards', async () => {
+      const node = element.shadowRoot!.querySelector('select')!;
+
+      node.value = 'xyz';
+      node.dispatchEvent(new Event('change'));
+      await element.updateComplete;
+
+      assert.is(element.prop, 'xyz');
+    });
+  });
+
+  suite('<select multiple>', () => {
+    setup(async () => {
+      element.template = () => html`
+        <select ${bindInput(element, 'prop')} multiple>
+          <option>808</option>
+          <option>303</option>
+        </select>
+      `;
+      await element.updateComplete;
+    });
+
+    test('propagates value downwards', async () => {
+      element.prop = ['808', '303'];
+      await element.updateComplete;
+
+      const node = element.shadowRoot!.querySelector('select')!;
+      const opts = [...node.selectedOptions].map((opt) => opt.value);
+
+      assert.is(opts.length, 2);
+      assert.equal(opts, ['808', '303']);
+    });
+
+    test('propagates value upwards', async () => {
+      const node = element.shadowRoot!.querySelector('select')!;
+      const opts = [...node.options];
+
+      opts[0]!.selected = true;
+      opts[1]!.selected = true;
+      node.dispatchEvent(new Event('change'));
+      await element.updateComplete;
+
+      assert.equal(element.prop, ['808', '303']);
+    });
+  });
+
+  suite('<textarea>', () => {
+    setup(async () => {
+      element.template = () => html`
+        <textarea ${bindInput(element, 'prop')}></textarea>
+      `;
+      await element.updateComplete;
+    });
+
+    test('propagates value downwards', async () => {
+      element.prop = 'xyz';
+      await element.updateComplete;
+
+      const node = element.shadowRoot!.querySelector('textarea')!;
+
+      assert.is(node.value, 'xyz');
+    });
+
+    test('propagates value upwards', async () => {
+      const node = element.shadowRoot!.querySelector('textarea')!;
+
+      node.value = 'xyz';
+      node.dispatchEvent(new Event('input'));
+      await element.updateComplete;
+
+      assert.is(element.prop, 'xyz');
+    });
+  });
+});


### PR DESCRIPTION
`bindInput` allows you to two-way bind a property to a given input-like element:

```ts
html`
  <input type="text" ${bindInput(this, 'name')}>

  <input type="checkbox" ${bindInput(this, 'enabled')}>

  <select ${bindInput(this, 'roles')}>
    <option>Admin</option>
    <option>User</option>
  </select>
`;
```