### PR TITLE
feat (bindInput): allow attr/prop bindings

### DIFF
--- a/docs/bindInput.md
+++ b/docs/bindInput.md
@@ -29,6 +29,22 @@ The parameters (`bindInput(host, property)`) are as follows:
 - `host` - any object which has the specified `property`
 - `property` - the name of the property on `host` to bind
 
+### By attribute/property
+
+You may also use this directive with an attribute or property binding:
+
+```ts
+    return html`
+      <label>
+        Name:
+        <input type="text" .value=${bindInput(this, 'name')}>
+      </label>
+    `;
+```
+
+This may help with SSR, and will work the same way as the element binding
+usage.
+
 ## Supported elements
 
 The following elements are supported by this directive:

--- a/src/test/directives/bindInput_test.ts
+++ b/src/test/directives/bindInput_test.ts
@@ -43,7 +43,8 @@ suite('bindInput directive', () => {
     } catch (err) {
       assert.is(
         (err as Error).message,
-        'The `bindInput` directive must be used in an element binding'
+        'The `bindInput` directive must be used in an element or ' +
+          'attribute binding'
       );
     }
   });
@@ -98,6 +99,62 @@ suite('bindInput directive', () => {
     assert.is(element.prop, 'xyz');
   });
 
+  suite('<input> by property', () => {
+    setup(async () => {
+      element.template = () => html`
+        <input .value=${bindInput(element, 'prop')}>
+      `;
+      await element.updateComplete;
+    });
+
+    test('propagates value downwards', async () => {
+      element.prop = 'xyz';
+      await element.updateComplete;
+
+      const inputNode = element.shadowRoot!.querySelector('input')!;
+
+      assert.is(inputNode.value, 'xyz');
+    });
+
+    test('propagates value upwards', async () => {
+      const inputNode = element.shadowRoot!.querySelector('input')!;
+
+      inputNode.value = 'xyz';
+      inputNode.dispatchEvent(new Event('input'));
+      await element.updateComplete;
+
+      assert.is(element.prop, 'xyz');
+    });
+  });
+
+  suite('<input> by attribute', () => {
+    setup(async () => {
+      element.template = () => html`
+        <input value=${bindInput(element, 'prop')}>
+      `;
+      await element.updateComplete;
+    });
+
+    test('propagates value downwards', async () => {
+      element.prop = 'xyz';
+      await element.updateComplete;
+
+      const inputNode = element.shadowRoot!.querySelector('input')!;
+
+      assert.is(inputNode.value, 'xyz');
+    });
+
+    test('propagates value upwards', async () => {
+      const inputNode = element.shadowRoot!.querySelector('input')!;
+
+      inputNode.value = 'xyz';
+      inputNode.dispatchEvent(new Event('input'));
+      await element.updateComplete;
+
+      assert.is(element.prop, 'xyz');
+    });
+  });
+
   suite('<input>', () => {
     setup(async () => {
       element.template = () => html`
@@ -123,6 +180,17 @@ suite('bindInput directive', () => {
       await element.updateComplete;
 
       assert.is(element.prop, 'xyz');
+    });
+
+    test('sets empty string on undefined value', async () => {
+      element.prop = 'xyz';
+      await element.updateComplete;
+      element.prop = undefined;
+      await element.updateComplete;
+
+      const inputNode = element.shadowRoot!.querySelector('input')!;
+
+      assert.is(inputNode.value, '');
     });
   });
 
@@ -244,6 +312,17 @@ suite('bindInput directive', () => {
       await element.updateComplete;
 
       assert.is(element.prop, 'xyz');
+    });
+
+    test('sets empty string on undefined value', async () => {
+      element.prop = 'xyz';
+      await element.updateComplete;
+      element.prop = undefined;
+      await element.updateComplete;
+
+      const node = element.shadowRoot!.querySelector('textarea')!;
+
+      assert.is(node.value, '');
     });
   });
 });


### PR DESCRIPTION
This enables the use of the `bindInput` directive in property and attribute bindings.

For example:

```ts
html`
  <input type="text" .value=${bindInput(this, 'prop')}>
`;
```

This may be beneficial for SSR in particular.

Behaviour will be the same as an element binding but will delegate setting of the element's value to lit rather than the directive dealing with it.

Of course this won't be possible with a multi-select `<select>` element since there is no property to bind to in that situation.

cc @e111077 maybe something like this?