### PR TITLE
feat (slot): add slot controller

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,4 +15,5 @@ The following is the full list of available utilities:
 - [permissions](./permissions.md) - track the state of a browser [permission](https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query)
 - [propertyHistory](./propertyHistory.md) - track the history of a property with undo/redo
 - [sessionStorage](./sessionStorage.md) - items in [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
+- [slot](./slot.md) - track slotted elements
 - [windowScroll](./windowScroll.md) - track the window scroll offset

--- a/docs/slot.md
+++ b/docs/slot.md
@@ -1,0 +1,65 @@
+# slot
+
+`slot` allows you to react to changes in your [slotted](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot)
+elements.
+
+For example, if you'd like to observe when a particular type of node is
+slotted into your element.
+
+## Usage
+
+```ts
+class MyElement extends LitElement {
+  constructor() {
+    super();
+
+    this._slotCtrl = new SlotController(this);
+
+    this._slotCtrl.addListener('*', (node) => {
+      // I am called every time a new node enters the slot
+    });
+  }
+
+  render() {
+    return html`
+      <slot ${ref(this.slotCtrl.ref)}>
+      </slot>
+    `;
+  }
+}
+```
+
+## Options
+
+When constructing the slot controller, a [`ref`](https://lit.dev/docs/templates/directives/#ref)
+is automatically created.
+
+You may override this by passing your own ref:
+
+```ts
+const myRef = createRef();
+const ctrl = new SlotController(host, myRef);
+```
+
+## Methods
+
+### `addListener(selector, callback)`
+
+This adds a listener to the controller which will be called any time an element
+is slotted into the referenced slot and matches the `selector`.
+
+For example:
+
+```ts
+ctrl.addListener('*', (node) => {
+  // I am called when any element is slotted
+});
+```
+
+The selector is any valid CSS selector:
+
+```ts
+ctrl.addListener('div', (node) => {
+  // I am called when a `<div>` is slotted
+});
+```

--- a/src/_internal/elementTracking.ts
+++ b/src/_internal/elementTracking.ts
@@ -7,7 +7,7 @@ import type {Ref} from 'lit/directives/ref.js';
  */
 export class ElementTrackingController implements ReactiveController {
   protected _host: ReactiveControllerHost & Element;
-  private __ref?: Ref;
+  protected _ref?: Ref;
   private __currentElement: Element | undefined = undefined;
 
   /**
@@ -15,8 +15,8 @@ export class ElementTrackingController implements ReactiveController {
    * @return {Element|undefined}
    */
   protected get _element(): Element | undefined {
-    if (this.__ref) {
-      return this.__ref.value;
+    if (this._ref) {
+      return this._ref.value;
     }
     return this._host;
   }
@@ -29,24 +29,27 @@ export class ElementTrackingController implements ReactiveController {
   public constructor(host: ReactiveControllerHost & Element, ref?: Ref | null) {
     this._host = host;
     if (ref) {
-      this.__ref = ref;
+      this._ref = ref;
     }
   }
 
   /** @inheritdoc */
   public hostUpdated(): void {
     const element = this._element;
-    if (element !== this.__currentElement) {
+    const prevElement = this.__currentElement;
+    if (element !== prevElement) {
       this.__currentElement = element;
-      this._onElementChanged();
+      this._onElementChanged(prevElement);
     }
   }
 
   /**
    * Fired when the current observed element changed
+   * @param {Element|undefined} _previousElement Previous element before it
+   * changed
    * @return {void}
    */
-  protected _onElementChanged(): void {
+  protected _onElementChanged(_previousElement: Element | undefined): void {
     return;
   }
 }

--- a/src/controllers/elementSize.ts
+++ b/src/controllers/elementSize.ts
@@ -81,8 +81,8 @@ export class ElementSizeController extends ElementTrackingController {
   }
 
   /** @inheritdoc */
-  protected override _onElementChanged(): void {
-    super._onElementChanged();
+  protected override _onElementChanged(prevElement: Element | undefined): void {
+    super._onElementChanged(prevElement);
 
     this.__observer.disconnect();
 

--- a/src/controllers/slot.ts
+++ b/src/controllers/slot.ts
@@ -1,0 +1,116 @@
+import type {ReactiveControllerHost} from 'lit';
+import type {Ref} from 'lit/directives/ref.js';
+import {createRef} from 'lit/directives/ref.js';
+import {ElementTrackingController} from '../_internal/elementTracking.js';
+
+/**
+ * Determines if a node is a slot element
+ * @param {Element} node Node to test
+ * @return {boolean}
+ */
+function isSlotElement(node: Element): node is HTMLSlotElement {
+  return node.nodeName === 'SLOT';
+}
+
+type SlotListenerCallback<T extends Element> = (node: T) => void;
+
+interface SlotListener {
+  selector: string;
+  callback: SlotListenerCallback<Element>;
+}
+
+/**
+ * Helpers for dealing with slotted content
+ */
+export class SlotController extends ElementTrackingController {
+  /**
+   * Gets the current ref
+   * @return {Ref}
+   */
+  public get ref(): Ref {
+    // Casting here to drop the nullability
+    return this._ref as Ref;
+  }
+
+  /**
+   * @param {ReactiveControllerHost} host Host to attach to
+   * @param {Ref} ref Ref to observe rather than the host element
+   */
+  public constructor(
+    host: ReactiveControllerHost & Element,
+    ref: Ref = createRef()
+  ) {
+    super(host, ref);
+
+    host.addController(this);
+  }
+
+  private __listeners: Set<SlotListener> = new Set<SlotListener>();
+
+  /**
+   * Binds a function to be called any time elements matching the specified
+   * selector are slotted into the slot
+   * @param {string} selector Query selector to filter elements by. Set this
+   * to `*` for all elements
+   * @param {SlotListenerCallback} callback Callback to call
+   * @return {void}
+   */
+  public addListener<T extends keyof HTMLElementTagNameMap>(
+    selector: T,
+    callback: SlotListenerCallback<HTMLElementTagNameMap[T]>
+  ): void;
+
+  /** @inheritdoc */
+  public addListener(
+    selector: string,
+    callback: SlotListenerCallback<Element>
+  ): void;
+
+  /** @inheritdoc */
+  public addListener(
+    selector: string,
+    callback: SlotListenerCallback<Element>
+  ): void {
+    this.__listeners.add({
+      selector,
+      callback
+    });
+  }
+
+  /**
+   * Fired when a slot change event occurred
+   * @return {void}
+   */
+  private __onSlotChanged = (): void => {
+    const element = this._element;
+
+    if (!element || !isSlotElement(element)) {
+      return;
+    }
+
+    const nodes = element.assignedElements();
+
+    for (const listener of this.__listeners) {
+      for (const node of nodes) {
+        if (listener.selector === '*' || node.matches(listener.selector)) {
+          listener.callback(node);
+        }
+      }
+    }
+  };
+
+  /** @inheritdoc */
+  protected override _onElementChanged(prevElement: Element | undefined): void {
+    super._onElementChanged(prevElement);
+
+    if (prevElement) {
+      prevElement.removeEventListener('slotchange', this.__onSlotChanged);
+    }
+
+    const element = this._element;
+
+    if (element) {
+      element.addEventListener('slotchange', this.__onSlotChanged);
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,5 +10,6 @@ export * from './controllers/markdown.js';
 export * from './controllers/permissions.js';
 export * from './controllers/propertyHistory.js';
 export * from './controllers/sessionStorage.js';
+export * from './controllers/slot.js';
 export * from './controllers/windowScroll.js';
 export * from './directives/bindInput.js';

--- a/src/test/controllers/elementSize_test.ts
+++ b/src/test/controllers/elementSize_test.ts
@@ -7,7 +7,7 @@ import type {Ref} from 'lit/directives/ref.js';
 import {ElementSizeController} from '../../main.js';
 import type {TestElement} from '../util.js';
 
-suite('DocumentVisibilityController', () => {
+suite('ElementSizeController', () => {
   let element: TestElement;
   let controller: ElementSizeController;
 

--- a/src/test/controllers/slot_test.ts
+++ b/src/test/controllers/slot_test.ts
@@ -1,0 +1,108 @@
+import '../util.js';
+
+import {html} from 'lit';
+import * as hanbi from 'hanbi';
+import * as assert from 'uvu/assert';
+import {createRef, ref} from 'lit/directives/ref.js';
+import type {Ref} from 'lit/directives/ref.js';
+import {SlotController} from '../../main.js';
+import type {TestElement} from '../util.js';
+
+suite('SlotController', () => {
+  let element: TestElement;
+  let controller: SlotController;
+  let elementRef: Ref<HTMLElement>;
+
+  setup(() => {
+    element = document.createElement('test-element');
+  });
+
+  teardown(() => {
+    element.remove();
+  });
+
+  setup(async () => {
+    elementRef = createRef<HTMLElement>();
+    controller = new SlotController(element, elementRef);
+    element.controllers.push(controller);
+    element.template = () => html`<slot ${ref(elementRef)}></slot>`;
+    document.body.appendChild(element);
+    await element.updateComplete;
+  });
+
+  suite('addListener', () => {
+    test('calls listener with slotted elements', async () => {
+      const spy = hanbi.spy<(node: Element) => void>();
+
+      controller.addListener('*', spy.handler);
+
+      element.innerHTML = '<span>foo</span><div>bar</div>';
+      await element.updateComplete;
+
+      const spanNode = element.querySelector('span')!;
+      const divNode = element.querySelector('div')!;
+
+      assert.is(spy.callCount, 2);
+
+      const firstCall = spy.getCall(0);
+      const secondCall = spy.getCall(1);
+
+      assert.is(firstCall.args[0], spanNode);
+      assert.is(secondCall.args[0], divNode);
+    });
+
+    suite('options.selector', () => {
+      test('simple selector matches elements', async () => {
+        const spy = hanbi.spy<(node: HTMLSpanElement) => void>();
+
+        controller.addListener('span', spy.handler);
+
+        element.innerHTML = '<span>foo</span><div>bar</div>';
+        await element.updateComplete;
+
+        const spanNode = element.querySelector('span')!;
+
+        assert.is(spy.callCount, 1);
+
+        const firstCall = spy.getCall(0);
+
+        assert.is(firstCall.args[0], spanNode);
+      });
+
+      test('complex selector matches elements', async () => {
+        const spy = hanbi.spy<(node: Element) => void>();
+
+        controller.addListener('span,div', spy.handler);
+
+        element.innerHTML = '<span>foo</span><div>bar</div><h1>baz</h1>';
+        await element.updateComplete;
+
+        const spanNode = element.querySelector('span')!;
+        const divNode = element.querySelector('div')!;
+
+        assert.is(spy.callCount, 2);
+
+        const firstCall = spy.getCall(0);
+        const secondCall = spy.getCall(1);
+
+        assert.is(firstCall.args[0], spanNode);
+        assert.is(secondCall.args[0], divNode);
+      });
+    });
+
+    test('observes element changes', async () => {
+      const spy = hanbi.spy<(node: Element) => void>();
+
+      controller.addListener('*', spy.handler);
+
+      element.template = () =>
+        html`<div><slot ${ref(elementRef)}></slot></div>`;
+      await element.updateComplete;
+
+      element.innerHTML = '<span>foo</span><div>bar</div>';
+      await element.updateComplete;
+
+      assert.is(spy.callCount, 2);
+    });
+  });
+});


### PR DESCRIPTION
The slot controller allows you to observe slotted elements:

```ts
const ctrl = new SlotController(host);

// elsewhere...

html`
  <slot ${ref(ctrl.ref)}></slot>
`;
```

We can then listen for particular elements being slotted:

```ts
ctrl.addListener((divNode) => {
  // divNode is always a `<div>` here thanks to the selector
}, {selector: 'div'});
```

Fixes #10 

cc @e111077 if you wanna take a look, this is what we mentioned on discord