### PR TITLE
feat (slot): rework how slotcontroller works

### DIFF
--- a/docs/slot.md
+++ b/docs/slot.md
@@ -15,15 +15,14 @@ class MyElement extends LitElement {
 
     this._slotCtrl = new SlotController(this);
 
-    this._slotCtrl.addListener('*', (node) => {
-      // I am called every time a new node enters the slot
+    this._slotCtrl.addListener('[default]', '*', (node) => {
+      // I am called every time a new node enters the default slot
     });
   }
 
   render() {
     return html`
-      <slot ${ref(this.slotCtrl.ref)}>
-      </slot>
+      <slot></slot>
     `;
   }
 }
@@ -31,35 +30,67 @@ class MyElement extends LitElement {
 
 ## Options
 
-When constructing the slot controller, a [`ref`](https://lit.dev/docs/templates/directives/#ref)
-is automatically created.
-
-You may override this by passing your own ref:
-
-```ts
-const myRef = createRef();
-const ctrl = new SlotController(host, myRef);
-```
+N/A
 
 ## Methods
 
-### `addListener(selector, callback)`
+### `addListener(slot, selector, callback)`
 
 This adds a listener to the controller which will be called any time an element
 is slotted into the referenced slot and matches the `selector`.
 
+- `slot` may be the name of a slot, or a `Ref` of a slot element
+- `selector` must be a CSS selector
+- `callback` is a function called when matching elements are slotted
+
+In both `slot` and `selector`, you may use `*` to specify "all slots" or
+"all elements".
+
+You may also use `[default]` to reference the default slot.
+
 For example:
 
 ```ts
-ctrl.addListener('*', (node) => {
-  // I am called when any element is slotted
+ctrl.addListener('*', '*', (node) => {
+  // I am called when any element is slotted into any slot
+});
+
+ctrl.addListener('[default]', '*', (node) => {
+  // I am called when any element is slotted into the default slot
+});
+
+ctrl.addListener('myslot', '*', (node) => {
+  // I am called when any element is slotted into a slot with the name "myslot"
+});
+
+ctrl.addListener('[default]', 'span', (node) => {
+  // I am called when a <span> is slotted into the default slot
 });
 ```
 
-The selector is any valid CSS selector:
+### `has(slot[, selector, options])`
+
+This can be used to determine if the current host element has slotted elements
+in a given slot.
+
+A selector may also be specified to narrow the selection.
+
+For example:
 
 ```ts
-ctrl.addListener('div', (node) => {
-  // I am called when a `<div>` is slotted
-});
+// true if the default slot has elements
+ctrl.has('[default]');
+
+// true if any slots have slotted elements
+ctrl.has('*');
+
+// true if the <slot> named "foo" has slotted elements
+ctrl.has('foo');
+
+// true if a `<span>` has been slotted into the default slot
+ctrl.has('[default]', 'span');
 ```
+
+You may also specify `options` to further customise the behaviour:
+
+- `options.flatten` - see [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements#flatten)

--- a/src/controllers/slot.ts
+++ b/src/controllers/slot.ts
@@ -1,7 +1,5 @@
-import type {ReactiveControllerHost} from 'lit';
+import type {ReactiveControllerHost, ReactiveController} from 'lit';
 import type {Ref} from 'lit/directives/ref.js';
-import {createRef} from 'lit/directives/ref.js';
-import {ElementTrackingController} from '../_internal/elementTracking.js';
 
 /**
  * Determines if a node is a slot element
@@ -12,9 +10,52 @@ function isSlotElement(node: Element): node is HTMLSlotElement {
   return node.nodeName === 'SLOT';
 }
 
+const defaultSlotName = '[default]';
+
+/**
+ * Determines if a given slot string/ref matches the specified slot
+ * @param {HTMLSlotElement} node Node to test against
+ * @param {string|Ref} matcher Ref or selector to match
+ * @return {boolean}
+ */
+function slotMatches(
+  node: HTMLSlotElement,
+  matcher: string | Ref<HTMLSlotElement>
+): boolean {
+  if (matcher === defaultSlotName && !node.hasAttribute('name')) {
+    return true;
+  }
+
+  if (typeof matcher !== 'string') {
+    return matcher.value === node;
+  }
+
+  return matcher === node.name;
+}
+
+/**
+ * Determines the slot name from a string or ref
+ * @param {string|Ref} slot Slot to retrieve name from
+ * @return {string|null}
+ */
+function getSlotName(slot: string | Ref<HTMLSlotElement>): string | null {
+  if (typeof slot === 'string') {
+    return slot;
+  }
+  if (!slot.value) {
+    return null;
+  }
+  return slot.value.name || '[default]';
+}
+
 type SlotListenerCallback<T extends Element> = (node: T) => void;
 
+export interface HasOptions {
+  flatten?: boolean;
+}
+
 interface SlotListener {
+  slot: string | Ref<HTMLSlotElement>;
   selector: string;
   callback: SlotListenerCallback<Element>;
 }
@@ -22,56 +63,104 @@ interface SlotListener {
 /**
  * Helpers for dealing with slotted content
  */
-export class SlotController extends ElementTrackingController {
+export class SlotController implements ReactiveController {
+  private __host: ReactiveControllerHost & Element;
+  private __hasCalled: boolean = false;
+  private __listeners: Set<SlotListener> = new Set<SlotListener>();
+
   /**
-   * Gets the current ref
-   * @return {Ref}
+   * Gets the slot elements in the current host
+   * @return {HTMLSlotElement[]}
    */
-  public get ref(): Ref {
-    // Casting here to drop the nullability
-    return this._ref as Ref;
+  private get __slots(): HTMLSlotElement[] {
+    if (!this.__host.shadowRoot) {
+      return [];
+    }
+
+    return [...this.__host.shadowRoot.querySelectorAll('slot')];
   }
 
   /**
    * @param {ReactiveControllerHost} host Host to attach to
-   * @param {Ref} ref Ref to observe rather than the host element
    */
-  public constructor(
-    host: ReactiveControllerHost & Element,
-    ref: Ref = createRef()
-  ) {
-    super(host, ref);
+  public constructor(host: ReactiveControllerHost & Element) {
+    this.__host = host;
 
     host.addController(this);
   }
 
-  private __listeners: Set<SlotListener> = new Set<SlotListener>();
+  /**
+   * Determines if a given slot has contents in the host
+   * @param {string|Ref} slot Slot to test against, * for all slots
+   * @param {string} selector Selector to test
+   * @param {object} options Options for detection
+   * @return {boolean}
+   */
+  public has(
+    slot: string | Ref<HTMLSlotElement>,
+    selector?: string,
+    options?: HasOptions
+  ): boolean {
+    const slotName = getSlotName(slot);
+    const flatten = options?.flatten === true;
+
+    this.__hasCalled = true;
+
+    if (!slotName) {
+      return false;
+    }
+
+    const slots = this.__slots.filter((slot) => {
+      return (
+        slotName === '*' ||
+        (!slot.hasAttribute('name') && slotName === defaultSlotName) ||
+        slot.name === slotName
+      );
+    });
+
+    for (const slot of slots) {
+      for (const child of slot.assignedElements({flatten})) {
+        // If there's no selector, return as soon as we've seen a child.
+        // Otherwise, return once we see a matching child.
+        if (!selector || child.matches(selector)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
 
   /**
    * Binds a function to be called any time elements matching the specified
-   * selector are slotted into the slot
+   * selector are slotted into a given slot
+   * @param {string|Ref} slot Slot to observe, * for all slots
    * @param {string} selector Query selector to filter elements by. Set this
    * to `*` for all elements
    * @param {SlotListenerCallback} callback Callback to call
    * @return {void}
    */
   public addListener<T extends keyof HTMLElementTagNameMap>(
+    slot: string | Ref<HTMLSlotElement>,
     selector: T,
     callback: SlotListenerCallback<HTMLElementTagNameMap[T]>
   ): void;
 
   /** @inheritdoc */
   public addListener(
+    slot: string | Ref<HTMLSlotElement>,
     selector: string,
     callback: SlotListenerCallback<Element>
   ): void;
 
   /** @inheritdoc */
   public addListener(
+    slot: string | Ref<HTMLSlotElement>,
     selector: string,
     callback: SlotListenerCallback<Element>
   ): void {
     this.__listeners.add({
+      slot,
       selector,
       callback
     });
@@ -79,38 +168,53 @@ export class SlotController extends ElementTrackingController {
 
   /**
    * Fired when a slot change event occurred
+   * @param {Event} ev Event fired
    * @return {void}
    */
-  private __onSlotChanged = (): void => {
-    const element = this._element;
+  private __onSlotChanged = (ev: Event): void => {
+    const element = ev.target as Element;
 
-    if (!element || !isSlotElement(element)) {
+    if (!isSlotElement(element)) {
       return;
     }
 
     const nodes = element.assignedElements();
 
     for (const listener of this.__listeners) {
+      if (listener.slot !== '*' && !slotMatches(element, listener.slot)) {
+        continue;
+      }
+
       for (const node of nodes) {
         if (listener.selector === '*' || node.matches(listener.selector)) {
           listener.callback(node);
         }
       }
     }
+
+    if (this.__hasCalled) {
+      this.__host.requestUpdate();
+    }
   };
 
   /** @inheritdoc */
-  protected override _onElementChanged(prevElement: Element | undefined): void {
-    super._onElementChanged(prevElement);
+  public hostUpdate(): void {
+    this.__hasCalled = false;
+  }
 
-    if (prevElement) {
-      prevElement.removeEventListener('slotchange', this.__onSlotChanged);
-    }
+  /** @inheritdoc */
+  public hostConnected(): void {
+    this.__host.shadowRoot?.addEventListener(
+      'slotchange',
+      this.__onSlotChanged
+    );
+  }
 
-    const element = this._element;
-
-    if (element) {
-      element.addEventListener('slotchange', this.__onSlotChanged);
-    }
+  /** @inheritdoc */
+  public hostDisconnected(): void {
+    this.__host.shadowRoot?.removeEventListener(
+      'slotchange',
+      this.__onSlotChanged
+    );
   }
 }

--- a/src/test/controllers/slot_test.ts
+++ b/src/test/controllers/slot_test.ts
@@ -3,15 +3,13 @@ import '../util.js';
 import {html} from 'lit';
 import * as hanbi from 'hanbi';
 import * as assert from 'uvu/assert';
-import {createRef, ref} from 'lit/directives/ref.js';
-import type {Ref} from 'lit/directives/ref.js';
 import {SlotController} from '../../main.js';
 import type {TestElement} from '../util.js';
+import {ref, createRef} from 'lit/directives/ref.js';
 
 suite('SlotController', () => {
   let element: TestElement;
   let controller: SlotController;
-  let elementRef: Ref<HTMLElement>;
 
   setup(() => {
     element = document.createElement('test-element');
@@ -22,10 +20,9 @@ suite('SlotController', () => {
   });
 
   setup(async () => {
-    elementRef = createRef<HTMLElement>();
-    controller = new SlotController(element, elementRef);
+    controller = new SlotController(element);
     element.controllers.push(controller);
-    element.template = () => html`<slot ${ref(elementRef)}></slot>`;
+    element.template = () => html`<slot></slot>`;
     document.body.appendChild(element);
     await element.updateComplete;
   });
@@ -34,7 +31,7 @@ suite('SlotController', () => {
     test('calls listener with slotted elements', async () => {
       const spy = hanbi.spy<(node: Element) => void>();
 
-      controller.addListener('*', spy.handler);
+      controller.addListener('*', '*', spy.handler);
 
       element.innerHTML = '<span>foo</span><div>bar</div>';
       await element.updateComplete;
@@ -51,58 +48,293 @@ suite('SlotController', () => {
       assert.is(secondCall.args[0], divNode);
     });
 
-    suite('options.selector', () => {
-      test('simple selector matches elements', async () => {
-        const spy = hanbi.spy<(node: HTMLSpanElement) => void>();
+    test('does not call listener for other slot', async () => {
+      const spy = hanbi.spy<(node: Element) => void>();
 
-        controller.addListener('span', spy.handler);
+      element.template = () => html`
+        <slot name="test"></slot>
+        <slot name="test2"></slot>
+      `;
+      await element.updateComplete;
 
-        element.innerHTML = '<span>foo</span><div>bar</div>';
-        await element.updateComplete;
+      controller.addListener('test', '*', spy.handler);
 
-        const spanNode = element.querySelector('span')!;
+      element.innerHTML = `
+        <span slot="test2">foo</span>
+      `;
+      await element.updateComplete;
 
-        assert.is(spy.callCount, 1);
+      assert.is(spy.callCount, 0);
+    });
 
-        const firstCall = spy.getCall(0);
+    test('simple selector matches elements', async () => {
+      const spy = hanbi.spy<(node: HTMLSpanElement) => void>();
 
-        assert.is(firstCall.args[0], spanNode);
-      });
+      controller.addListener('*', 'span', spy.handler);
 
-      test('complex selector matches elements', async () => {
-        const spy = hanbi.spy<(node: Element) => void>();
+      element.innerHTML = '<span>foo</span><div>bar</div>';
+      await element.updateComplete;
 
-        controller.addListener('span,div', spy.handler);
+      const spanNode = element.querySelector('span')!;
 
-        element.innerHTML = '<span>foo</span><div>bar</div><h1>baz</h1>';
-        await element.updateComplete;
+      assert.is(spy.callCount, 1);
 
-        const spanNode = element.querySelector('span')!;
-        const divNode = element.querySelector('div')!;
+      const firstCall = spy.getCall(0);
 
-        assert.is(spy.callCount, 2);
+      assert.is(firstCall.args[0], spanNode);
+    });
 
-        const firstCall = spy.getCall(0);
-        const secondCall = spy.getCall(1);
+    test('complex selector matches elements', async () => {
+      const spy = hanbi.spy<(node: Element) => void>();
 
-        assert.is(firstCall.args[0], spanNode);
-        assert.is(secondCall.args[0], divNode);
-      });
+      controller.addListener('*', 'span,div', spy.handler);
+
+      element.innerHTML = '<span>foo</span><div>bar</div><h1>baz</h1>';
+      await element.updateComplete;
+
+      const spanNode = element.querySelector('span')!;
+      const divNode = element.querySelector('div')!;
+
+      assert.is(spy.callCount, 2);
+
+      const firstCall = spy.getCall(0);
+      const secondCall = spy.getCall(1);
+
+      assert.is(firstCall.args[0], spanNode);
+      assert.is(secondCall.args[0], divNode);
     });
 
     test('observes element changes', async () => {
       const spy = hanbi.spy<(node: Element) => void>();
 
-      controller.addListener('*', spy.handler);
+      controller.addListener('*', '*', spy.handler);
 
-      element.template = () =>
-        html`<div><slot ${ref(elementRef)}></slot></div>`;
+      element.template = () => html`<div><slot></slot></div>`;
       await element.updateComplete;
 
       element.innerHTML = '<span>foo</span><div>bar</div>';
       await element.updateComplete;
 
       assert.is(spy.callCount, 2);
+    });
+
+    test('can specify exact slot by name', async () => {
+      const spy = hanbi.spy<(node: Element) => void>();
+
+      element.template = () => html`<slot name="test"></slot>`;
+      await element.updateComplete;
+
+      controller.addListener('test', '*', spy.handler);
+
+      element.innerHTML = '<span slot="test">foo</span><div>bar</div>';
+      await element.updateComplete;
+
+      const spanNode = element.querySelector('span')!;
+
+      assert.is(spy.callCount, 1);
+
+      const firstCall = spy.getCall(0);
+
+      assert.is(firstCall.args[0], spanNode);
+    });
+
+    test('can specify exact slot by ref', async () => {
+      const spy = hanbi.spy<(node: Element) => void>();
+      const slotRef = createRef<HTMLSlotElement>();
+
+      element.template = () => html`
+        <slot name="test" ${ref(slotRef)}></slot>
+      `;
+      await element.updateComplete;
+
+      controller.addListener(slotRef, '*', spy.handler);
+
+      element.innerHTML = '<span slot="test">foo</span><div>bar</div>';
+      await element.updateComplete;
+
+      const spanNode = element.querySelector('span')!;
+
+      assert.is(spy.callCount, 1);
+
+      const firstCall = spy.getCall(0);
+
+      assert.is(firstCall.args[0], spanNode);
+    });
+
+    test('can specify default slot', async () => {
+      const spy = hanbi.spy<(node: Element) => void>();
+
+      controller.addListener('[default]', '*', spy.handler);
+
+      element.innerHTML = '<span>foo</span><div>bar</div>';
+      await element.updateComplete;
+
+      const spanNode = element.querySelector('span')!;
+      const divNode = element.querySelector('div')!;
+
+      assert.is(spy.callCount, 2);
+
+      const firstCall = spy.getCall(0);
+      const secondCall = spy.getCall(1);
+
+      assert.is(firstCall.args[0], spanNode);
+      assert.is(secondCall.args[0], divNode);
+    });
+  });
+
+  suite('has', () => {
+    test('false if no slot name', async () => {
+      assert.is(controller.has(''), false);
+    });
+
+    test('true if slot has elements', async () => {
+      element.template = () => html`
+        <slot name="test"></slot>
+      `;
+      await element.updateComplete;
+
+      assert.is(controller.has('test'), false);
+
+      element.innerHTML = `
+        <span slot="test">foo</span>
+      `;
+
+      assert.is(controller.has('test'), true);
+    });
+
+    test('can pass slot as ref', async () => {
+      const slotRef = createRef<HTMLSlotElement>();
+
+      element.template = () => html`
+        <slot name="test" ${ref(slotRef)}></slot>
+      `;
+      await element.updateComplete;
+
+      assert.is(controller.has(slotRef), false);
+
+      element.innerHTML = `
+        <span slot="test">foo</span>
+      `;
+
+      assert.is(controller.has(slotRef), true);
+    });
+
+    test('true if any slot has elements (slot=*)', async () => {
+      element.template = () => html`
+        <slot name="test"></slot>
+        <slot></slot>
+      `;
+      await element.updateComplete;
+
+      assert.is(controller.has('*'), false);
+
+      element.innerHTML = `
+        <span slot="test">foo</span>
+        <span>bar</span>
+      `;
+
+      assert.is(controller.has('*'), true);
+    });
+
+    test('true if any slot has matching elements (slot=*)', async () => {
+      element.template = () => html`
+        <slot name="test"></slot>
+        <slot></slot>
+      `;
+      await element.updateComplete;
+
+      assert.is(controller.has('*', 'span'), false);
+
+      element.innerHTML = `
+        <div slot="test">foo</div>
+        <span>bar</span>
+      `;
+
+      assert.is(controller.has('*', 'span'), true);
+    });
+
+    test('true if slot has matching elements', async () => {
+      element.template = () => html`<slot name="test"></slot>`;
+      await element.updateComplete;
+
+      element.innerHTML = '<span slot="test">foo</span>';
+
+      assert.is(controller.has('test', 'span'), true);
+      assert.is(controller.has('test', 'div'), false);
+    });
+
+    test('true if default slot has elements', () => {
+      assert.is(controller.has('[default]'), false);
+
+      element.innerHTML = '<span>foo</span>';
+
+      assert.is(controller.has('[default]'), true);
+    });
+
+    test('false if not the specified slot', async () => {
+      element.template = () => html`
+        <slot name="test"></slot>
+        <slot name="test2"></slot>
+      `;
+      await element.updateComplete;
+
+      assert.is(controller.has('test'), false);
+
+      element.innerHTML = `
+        <div slot="test2">foo</div>
+      `;
+
+      assert.is(controller.has('test'), false);
+    });
+
+    test('triggers re-render when condition changes', async () => {
+      element.template = () => html`
+        <slot></slot>
+        <span>${String(controller.has('*'))}</span>
+      `;
+      await element.updateComplete;
+
+      const span = element.shadowRoot!.querySelector('span')!;
+
+      assert.is(span.textContent, 'false');
+
+      element.innerHTML = '<span>foo</span>';
+      await element.updateComplete;
+      await element.updateComplete;
+
+      assert.is(span.textContent, 'true');
+    });
+
+    test('handles re-renders with conditional has() calls', async () => {
+      let flag = true;
+
+      element.template = () => html`
+        <slot></slot>
+        <span>${flag ? String(controller.has('*')) : 'nothing'}</span>
+      `;
+      await element.updateComplete;
+
+      const span = element.shadowRoot!.querySelector('span')!;
+
+      assert.is(span.textContent, 'false');
+
+      flag = false;
+      element.requestUpdate();
+      await element.updateComplete;
+
+      assert.is(span.textContent, 'nothing');
+
+      flag = true;
+      element.requestUpdate();
+      await element.updateComplete;
+
+      assert.is(span.textContent, 'false');
+
+      element.innerHTML = '<span>foo</span>';
+      await element.updateComplete;
+      await element.updateComplete;
+
+      assert.is(span.textContent, 'true');
     });
   });
 });


### PR DESCRIPTION
This reworks the slot controller such that it deals with _multiple_ slots rather than a single slot.

This means `addListener` must now be given a slot to listen on:

```ts
ctrl.addListener('slotname', 'selector', fn);

// or by ref

ctrl.addListener(someRef, '*', fn);
```

Similarly, the new `has` method behaves the same:

```ts
// true if the slotname slot has elements
ctrl.has('slotname');
```

Using the `has` method will cause the controller to trigger re-renders from then on when slotted elements change.

It does this since its likely you used `has()` in your render method.

cc @e111077 would be nice to get your view when you get a few spare minutes