### PR TITLE
wip: add form controller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@types/marked": "^4.0.8",
+        "dlv": "^1.1.3",
+        "dset": "^3.1.2",
         "marked": "^4.2.12",
         "tslib": "^2.4.1"
       },
@@ -1858,6 +1860,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1868,6 +1875,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
+      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ee-first": {
@@ -6602,6 +6617,11 @@
         "path-type": "^4.0.0"
       }
     },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -6610,6 +6630,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dset": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
+      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
   },
   "dependencies": {
     "@types/marked": "^4.0.8",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.2",
     "marked": "^4.2.12",
     "tslib": "^2.4.1"
   }

--- a/src/controllers/form.ts
+++ b/src/controllers/form.ts
@@ -1,0 +1,189 @@
+import type {ReactiveController, ReactiveControllerHost} from 'lit';
+import {ref, createRef} from 'lit/directives/ref.js';
+import type {DirectiveResult} from 'lit/directive.js';
+import type {Ref, RefDirective} from 'lit/directives/ref.js';
+import delve from 'dlv';
+import {dset} from 'dset';
+
+/**
+ * Determines the field name of a given event target
+ * @param {EventTarget} target Target to retrieve name of
+ * @return {string|null}
+ */
+function getNameFromTarget(target: EventTarget): string | null {
+  const node = target as Element;
+  const name = node.getAttribute('name');
+  const id = node.getAttribute('id');
+
+  if (name) {
+    return name;
+  }
+
+  if (id) {
+    return id;
+  }
+
+  return null;
+}
+
+/**
+ * Determines if an event target is an element
+ * @param {EventTarget} target Target to check
+ * @return {boolean}
+ */
+function isElementNode(target: EventTarget): target is HTMLElement {
+  return (target as Node).nodeType === Node.ELEMENT_NODE;
+}
+
+/**
+ * Gets the value of a given event target
+ * @param {EventTarget} target Target to retrieve value from
+ * @return {unknown}
+ */
+function getValueFromTarget(target: EventTarget): unknown {
+  if (!isElementNode(target)) {
+    return undefined;
+  }
+
+  const type = target.getAttribute('type');
+  const possibleValue = (target as HTMLElement & {value: unknown}).value;
+
+  if (!type) {
+    return possibleValue;
+  }
+
+  if (type === 'number' || type === 'range') {
+    const asNumber = Number(possibleValue);
+    return Number.isNaN(asNumber) ? undefined : asNumber;
+  }
+
+  if (type === 'checkbox') {
+    const checked = (target as HTMLInputElement).checked;
+    // TODO (jg): handle arrays of checkboxes
+    return checked === true;
+  }
+
+  if (target.nodeName === 'SELECT') {
+    const options = (target as HTMLSelectElement).options;
+    const multiple = target.hasAttribute('multiple');
+
+    if (options && multiple) {
+      return Array.from(options)
+        .filter((option) => option.selected)
+        .map((option) => option.value);
+    }
+  }
+
+  return possibleValue;
+}
+
+export interface FormControllerOptions {
+  immutable?: boolean;
+}
+
+/**
+ * Forms
+ */
+export class FormController<T extends object> {
+  private __host: ReactiveControllerHost;
+  private __formRef: Ref<HTMLFormElement> = createRef<HTMLFormElement>();
+  private __options: FormControllerOptions;
+
+  public errors: Map<keyof T, string> = new Map<keyof T, string>();
+  public value: T;
+
+  /**
+   * Gets the currently attached form element
+   * @return {HTMLFormElement|undefined}
+   */
+  public get form(): HTMLFormElement | undefined {
+    return this.__formRef.value;
+  }
+
+  /**
+   * @param {ReactiveControllerHost} host Host to attach to
+   * @param {T} initialValue Initial value to set
+   * @param {FormOptions=} options Form options
+   */
+  public constructor(
+    host: ReactiveControllerHost,
+    initialValue: T,
+    options: FormControllerOptions = {}
+  ) {
+    this.__host = host;
+    this.__options = options;
+    this.value = initialValue;
+    host.addController(this as ReactiveController);
+  }
+
+  /**
+   * Call when a change occurs from a field
+   * @param {Event} ev Event fired
+   * @return {void}
+   */
+  public onChange = (ev: Event): void => {
+    this.__updateFromEvent(ev);
+  };
+
+  /**
+   * Call when a field loses focus
+   * @param {Event} _ev Event fired
+   * @return {void}
+   */
+  public onBlur = (_ev: Event): void => {
+    return;
+  };
+
+  /**
+   * Call when input occurs in a field
+   * @param {Event} ev Event fired
+   * @return {void}
+   */
+  public onInput = (ev: Event): void => {
+    this.__updateFromEvent(ev);
+  };
+
+  /**
+   * Updates the model based on a change-like event
+   * @param {Event} ev Event fired
+   * @return {void}
+   */
+  private __updateFromEvent(ev: Event): void {
+    if (!ev.currentTarget) {
+      return;
+    }
+
+    const fieldName = getNameFromTarget(ev.currentTarget);
+
+    if (fieldName === null) {
+      return;
+    }
+
+    const currentValue = delve(this.value, fieldName);
+    const newValue = getValueFromTarget(ev.currentTarget);
+
+    if (currentValue !== newValue) {
+      let value: T;
+
+      if (this.__options.immutable) {
+        value = window.structuredClone(this.value);
+      } else {
+        value = this.value;
+      }
+
+      dset(value, fieldName, newValue);
+
+      this.value = value;
+
+      this.__host.requestUpdate();
+    }
+  }
+
+  /**
+   * Attaches the controller to a `<form>` element
+   * @return {DirectiveResult}
+   */
+  public attach(): DirectiveResult<typeof RefDirective> {
+    return ref(this.__formRef);
+  }
+}

--- a/src/controllers/form.ts
+++ b/src/controllers/form.ts
@@ -132,6 +132,8 @@ export class FormController<T extends object> {
 
     const fieldValidators = this.__fieldValidators.get(prop);
 
+    this.errors.delete(prop);
+
     if (fieldValidators) {
       for (const validator of fieldValidators) {
         const result = validator(val);
@@ -156,8 +158,6 @@ export class FormController<T extends object> {
     if (!this.__formNode || this.__formNode !== target) {
       return;
     }
-
-    this.errors.clear();
 
     for (const validator of this.__validators) {
       const result = validator(this.value);

--- a/src/controllers/form.ts
+++ b/src/controllers/form.ts
@@ -2,7 +2,11 @@ import type {ReactiveController, ReactiveControllerHost} from 'lit';
 import {ref} from 'lit/directives/ref.js';
 import type {DirectiveResult} from 'lit/directive.js';
 import type {RefDirective} from 'lit/directives/ref.js';
-import {bindInput, type BindInputDirective} from '../directives/bindInput.js';
+import {
+  bindInput,
+  type BindInputDirective,
+  type BindInputKey
+} from '../directives/bindInput.js';
 
 export interface FormError {
   prop: PropertyKey;
@@ -54,7 +58,9 @@ export class FormController<T extends object> {
    * @param {string} path Path to bind to in the value
    * @return {DirectiveResult}
    */
-  public bind(path: string): DirectiveResult<typeof BindInputDirective> {
+  public bind(
+    path: BindInputKey<T>
+  ): DirectiveResult<typeof BindInputDirective> {
     return bindInput(this.value, path, {
       host: this.__host,
       validate: this.__validateInput

--- a/src/controllers/form.ts
+++ b/src/controllers/form.ts
@@ -4,14 +4,31 @@ import type {DirectiveResult} from 'lit/directive.js';
 import type {Ref, RefDirective} from 'lit/directives/ref.js';
 import {bindInput, type BindInputDirective} from '../directives/bindInput.js';
 
+export interface FormError {
+  prop: PropertyKey;
+  message: string;
+}
+
+export type FormFieldValidator<T> = (val: T) => string | null | void;
+
+export type FormValidator<T> = (val: T) => FormError[] | FormError | null;
+
 /**
  * Forms
  */
 export class FormController<T extends object> {
   private __host: ReactiveControllerHost;
   private __formRef: Ref<HTMLFormElement> = createRef<HTMLFormElement>();
+  private __fieldValidators: Map<
+    PropertyKey,
+    Set<FormFieldValidator<unknown>>
+  > = new Map<PropertyKey, Set<FormFieldValidator<unknown>>>();
+  private __validators: Set<FormValidator<T>> = new Set<FormValidator<T>>();
 
-  public errors: Map<keyof T, string> = new Map<keyof T, string>();
+  public readonly errors: Map<PropertyKey, string> = new Map<
+    PropertyKey,
+    string
+  >();
   public value: T;
 
   /**
@@ -39,9 +56,108 @@ export class FormController<T extends object> {
    */
   public bind(path: string): DirectiveResult<typeof BindInputDirective> {
     return bindInput(this.value, path, {
-      host: this.__host
+      host: this.__host,
+      validate: this.__validateInput
     });
   }
+
+  /**
+   * Adds a form-level validator to the form.
+   * The validator is given the entire form value each time user input
+   * is received
+   * @param {FormValidator<T>} validator Validation function
+   * @return {void}
+   */
+  public addValidator(validator: FormValidator<T>): void;
+
+  /**
+   * Adds a field-level validator to the form.
+   * The validator is given the field's value each time user input is
+   * received
+   * @param {PropertyKey} prop Property to validate
+   * @param {FormFieldValidator} validator Validation function
+   * @return {void}
+   */
+  public addValidator<TKey extends keyof T>(
+    prop: TKey,
+    validator: FormFieldValidator<T[TKey]>
+  ): void;
+
+  /**
+   * Adds a field-level validator to the form.
+   * The validator is given the field's value each time user input is
+   * received
+   * @param {PropertyKey} prop Property to validate
+   * @param {FormFieldValidator} validator Validation function
+   * @return {void}
+   */
+  public addValidator(
+    prop: PropertyKey,
+    validator: FormFieldValidator<unknown>
+  ): void;
+
+  /**
+   * Adds a validator to the form
+   * @param {PropertyKey|FormValidator<T>} propOrValidator Property or
+   * validator
+   * @param {FormFieldValidator=} validator Validation function if a property
+   * was specified
+   * @return {void}
+   */
+  public addValidator(
+    propOrValidator: PropertyKey | FormValidator<T>,
+    validator?: FormFieldValidator<unknown>
+  ): void {
+    if (typeof propOrValidator === 'function') {
+      this.__validators.add(propOrValidator);
+    } else {
+      const validators =
+        this.__fieldValidators.get(propOrValidator) ??
+        new Set<FormFieldValidator<unknown>>();
+      if (validator) {
+        validators.add(validator);
+      }
+      this.__fieldValidators.set(propOrValidator, validators);
+    }
+  }
+
+  /**
+   * Validates a specified property using the form's validators
+   * @param {unknown} val Value to validate
+   * @param {PropertyKey} prop Property being validated
+   * @return {boolean}
+   */
+  private __validateInput = (val: unknown, prop: PropertyKey): boolean => {
+    let valid = true;
+
+    for (const validator of this.__validators) {
+      const result = validator(this.value);
+
+      if (result) {
+        const asArr = Array.isArray(result) ? result : [result];
+        for (const err of asArr) {
+          if (err.prop === prop) {
+            valid = false;
+          }
+          this.errors.set(err.prop, err.message);
+        }
+      }
+    }
+
+    const fieldValidators = this.__fieldValidators.get(prop);
+
+    if (fieldValidators) {
+      for (const validator of fieldValidators) {
+        const result = validator(val);
+        if (result) {
+          valid = false;
+          this.errors.set(prop, result);
+        }
+      }
+    }
+
+    return valid;
+  };
 
   /**
    * Attaches the controller to a `<form>` element

--- a/src/controllers/form.ts
+++ b/src/controllers/form.ts
@@ -2,84 +2,7 @@ import type {ReactiveController, ReactiveControllerHost} from 'lit';
 import {ref, createRef} from 'lit/directives/ref.js';
 import type {DirectiveResult} from 'lit/directive.js';
 import type {Ref, RefDirective} from 'lit/directives/ref.js';
-import delve from 'dlv';
-import {dset} from 'dset';
-
-/**
- * Determines the field name of a given event target
- * @param {EventTarget} target Target to retrieve name of
- * @return {string|null}
- */
-function getNameFromTarget(target: EventTarget): string | null {
-  const node = target as Element;
-  const name = node.getAttribute('name');
-  const id = node.getAttribute('id');
-
-  if (name) {
-    return name;
-  }
-
-  if (id) {
-    return id;
-  }
-
-  return null;
-}
-
-/**
- * Determines if an event target is an element
- * @param {EventTarget} target Target to check
- * @return {boolean}
- */
-function isElementNode(target: EventTarget): target is HTMLElement {
-  return (target as Node).nodeType === Node.ELEMENT_NODE;
-}
-
-/**
- * Gets the value of a given event target
- * @param {EventTarget} target Target to retrieve value from
- * @return {unknown}
- */
-function getValueFromTarget(target: EventTarget): unknown {
-  if (!isElementNode(target)) {
-    return undefined;
-  }
-
-  const type = target.getAttribute('type');
-  const possibleValue = (target as HTMLElement & {value: unknown}).value;
-
-  if (!type) {
-    return possibleValue;
-  }
-
-  if (type === 'number' || type === 'range') {
-    const asNumber = Number(possibleValue);
-    return Number.isNaN(asNumber) ? undefined : asNumber;
-  }
-
-  if (type === 'checkbox') {
-    const checked = (target as HTMLInputElement).checked;
-    // TODO (jg): handle arrays of checkboxes
-    return checked === true;
-  }
-
-  if (target.nodeName === 'SELECT') {
-    const options = (target as HTMLSelectElement).options;
-    const multiple = target.hasAttribute('multiple');
-
-    if (options && multiple) {
-      return Array.from(options)
-        .filter((option) => option.selected)
-        .map((option) => option.value);
-    }
-  }
-
-  return possibleValue;
-}
-
-export interface FormControllerOptions {
-  immutable?: boolean;
-}
+import {bindInput, type BindInputDirective} from '../directives/bindInput.js';
 
 /**
  * Forms
@@ -87,7 +10,6 @@ export interface FormControllerOptions {
 export class FormController<T extends object> {
   private __host: ReactiveControllerHost;
   private __formRef: Ref<HTMLFormElement> = createRef<HTMLFormElement>();
-  private __options: FormControllerOptions;
 
   public errors: Map<keyof T, string> = new Map<keyof T, string>();
   public value: T;
@@ -103,80 +25,22 @@ export class FormController<T extends object> {
   /**
    * @param {ReactiveControllerHost} host Host to attach to
    * @param {T} initialValue Initial value to set
-   * @param {FormOptions=} options Form options
    */
-  public constructor(
-    host: ReactiveControllerHost,
-    initialValue: T,
-    options: FormControllerOptions = {}
-  ) {
-    this.__host = host;
-    this.__options = options;
+  public constructor(host: ReactiveControllerHost, initialValue: T) {
     this.value = initialValue;
+    this.__host = host;
     host.addController(this as ReactiveController);
   }
 
   /**
-   * Call when a change occurs from a field
-   * @param {Event} ev Event fired
-   * @return {void}
+   * Binds an input to this form
+   * @param {string} path Path to bind to in the value
+   * @return {DirectiveResult}
    */
-  public onChange = (ev: Event): void => {
-    this.__updateFromEvent(ev);
-  };
-
-  /**
-   * Call when a field loses focus
-   * @param {Event} _ev Event fired
-   * @return {void}
-   */
-  public onBlur = (_ev: Event): void => {
-    return;
-  };
-
-  /**
-   * Call when input occurs in a field
-   * @param {Event} ev Event fired
-   * @return {void}
-   */
-  public onInput = (ev: Event): void => {
-    this.__updateFromEvent(ev);
-  };
-
-  /**
-   * Updates the model based on a change-like event
-   * @param {Event} ev Event fired
-   * @return {void}
-   */
-  private __updateFromEvent(ev: Event): void {
-    if (!ev.currentTarget) {
-      return;
-    }
-
-    const fieldName = getNameFromTarget(ev.currentTarget);
-
-    if (fieldName === null) {
-      return;
-    }
-
-    const currentValue = delve(this.value, fieldName);
-    const newValue = getValueFromTarget(ev.currentTarget);
-
-    if (currentValue !== newValue) {
-      let value: T;
-
-      if (this.__options.immutable) {
-        value = window.structuredClone(this.value);
-      } else {
-        value = this.value;
-      }
-
-      dset(value, fieldName, newValue);
-
-      this.value = value;
-
-      this.__host.requestUpdate();
-    }
+  public bind(path: string): DirectiveResult<typeof BindInputDirective> {
+    return bindInput(this.value, path, {
+      host: this.__host
+    });
   }
 
   /**

--- a/src/directives/bindInput.ts
+++ b/src/directives/bindInput.ts
@@ -3,7 +3,9 @@ import {nothing, type ReactiveControllerHost} from 'lit';
 import type {
   ElementPart,
   DirectiveParameters,
-  PartInfo
+  PartInfo,
+  DirectiveResult,
+  DirectiveClass
 } from 'lit/directive.js';
 import {PartType} from 'lit/directive.js';
 import delve from 'dlv';
@@ -328,6 +330,10 @@ export class BindInputDirective extends AsyncDirective {
   }
 }
 
+const bindInputDirective = directive(BindInputDirective);
+
+export type BindInputKey<T> = keyof T | `${string}.${string}`;
+
 /**
  * Two-way binds a given property to the input it is defined on.
  *
@@ -341,6 +347,13 @@ export class BindInputDirective extends AsyncDirective {
  *
  * @param {T} host Host object of the property
  * @param {string} key Property to bind
+ * @param {BindInputOptions=} options Input binding options
  * @return {DirectiveResult}
  */
-export const bindInput = directive(BindInputDirective);
+export function bindInput<T, TKey extends BindInputKey<T>>(
+  host: T,
+  key: TKey,
+  options?: BindInputOptions
+): DirectiveResult<DirectiveClass> {
+  return bindInputDirective(host, key, options);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ export * from './controllers/activeElement.js';
 export * from './controllers/documentVisibility.js';
 export * from './controllers/elementSize.js';
 export * from './controllers/elementVisibility.js';
+export * from './controllers/form.js';
 export * from './controllers/head.js';
 export * from './controllers/itemSelection.js';
 export * from './controllers/keyBinding.js';

--- a/src/test/controllers/form_test.ts
+++ b/src/test/controllers/form_test.ts
@@ -257,7 +257,7 @@ suite('FormController', () => {
       await element.updateComplete;
 
       assert.is(lastVal, controller.value);
-      assert.equal(controller.value, {});
+      assert.equal(controller.value, {email: 'foo'});
       assert.is(controller.errors.size, 1);
       assert.is(controller.errors.get('email'), 'some error');
     });
@@ -278,7 +278,13 @@ suite('FormController', () => {
       input.dispatchEvent(new Event('change'));
       await element.updateComplete;
 
-      assert.equal(controller.value, {});
+      assert.is(controller.errors.size, 0);
+
+      const form = element.shadowRoot!.querySelector('form')!;
+      form.dispatchEvent(new Event('submit'));
+      await element.updateComplete;
+
+      assert.equal(controller.value, {email: 'foo'});
       assert.is(controller.errors.size, 1);
       assert.is(controller.errors.get('email'), 'some error');
     });
@@ -303,7 +309,13 @@ suite('FormController', () => {
       input.dispatchEvent(new Event('change'));
       await element.updateComplete;
 
-      assert.equal(controller.value, {});
+      assert.is(controller.errors.size, 0);
+
+      const form = element.shadowRoot!.querySelector('form')!;
+      form.dispatchEvent(new Event('submit'));
+      await element.updateComplete;
+
+      assert.equal(controller.value, {email: 'foo'});
       assert.is(controller.errors.size, 1);
       assert.is(controller.errors.get('email'), 'error 1');
     });

--- a/src/test/controllers/form_test.ts
+++ b/src/test/controllers/form_test.ts
@@ -183,7 +183,7 @@ suite('FormController', () => {
       await element.updateComplete;
     });
 
-    test('field validator with error populates errors', async () => {
+    test('field validator can return error', async () => {
       let lastVal: string | undefined;
 
       controller.addValidator('email', (val) => {
@@ -201,6 +201,21 @@ suite('FormController', () => {
       assert.equal(controller.value, {});
       assert.is(controller.errors.size, 1);
       assert.is(controller.errors.get('email'), 'some error');
+    });
+
+    test('field validator can null', async () => {
+      controller.addValidator('email', () => {
+        return null;
+      });
+
+      const input =
+        element.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+      input.value = 'foo';
+      input.dispatchEvent(new Event('change'));
+      await element.updateComplete;
+
+      assert.equal(controller.value, {email: 'foo'});
+      assert.is(controller.errors.size, 0);
     });
 
     test('form validator can return single error', async () => {

--- a/src/test/controllers/form_test.ts
+++ b/src/test/controllers/form_test.ts
@@ -203,9 +203,24 @@ suite('FormController', () => {
       assert.is(controller.errors.get('email'), 'some error');
     });
 
-    test('field validator can null', async () => {
+    test('field validator can return null', async () => {
       controller.addValidator('email', () => {
         return null;
+      });
+
+      const input =
+        element.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+      input.value = 'foo';
+      input.dispatchEvent(new Event('change'));
+      await element.updateComplete;
+
+      assert.equal(controller.value, {email: 'foo'});
+      assert.is(controller.errors.size, 0);
+    });
+
+    test('field validator can return void', async () => {
+      controller.addValidator('email', () => {
+        return;
       });
 
       const input =
@@ -235,7 +250,13 @@ suite('FormController', () => {
       input.dispatchEvent(new Event('change'));
       await element.updateComplete;
 
-      assert.equal(lastVal, {});
+      assert.is(controller.errors.size, 0);
+
+      const form = element.shadowRoot!.querySelector('form')!;
+      form.dispatchEvent(new Event('submit'));
+      await element.updateComplete;
+
+      assert.is(lastVal, controller.value);
       assert.equal(controller.value, {});
       assert.is(controller.errors.size, 1);
       assert.is(controller.errors.get('email'), 'some error');

--- a/src/test/controllers/form_test.ts
+++ b/src/test/controllers/form_test.ts
@@ -1,0 +1,293 @@
+import '../util.js';
+
+import {html} from 'lit';
+import type {ReactiveController} from 'lit';
+import * as assert from 'uvu/assert';
+import {FormController, type FormControllerOptions} from '../../main.js';
+import type {TestElement} from '../util.js';
+
+/**
+ * Creates a form controller fixture
+ * @param {*} value Initial value
+ * @param {FormControllerOptions} options Options for the controller
+ * @return {Promise}
+ */
+async function fixture<T extends object>(
+  value: T,
+  options: FormControllerOptions
+): Promise<{
+  element: TestElement;
+  controller: FormController<T>;
+}> {
+  const element = document.createElement('test-element') as TestElement;
+  const controller = new FormController<T>(element, value, options);
+  element.controllers.push(controller as ReactiveController);
+  element.template = () => html`
+    <div id="value">${JSON.stringify(value)}</div>
+    <form ${controller.attach()}>
+    </form>
+  `;
+  document.body.appendChild(element);
+  await element.updateComplete;
+
+  return {
+    element,
+    controller
+  };
+}
+
+suite('FormController', () => {
+  let element: TestElement;
+
+  teardown(() => {
+    element.remove();
+  });
+
+  suite('default', () => {
+    let value: {email?: string};
+    let controller: FormController<typeof value>;
+
+    setup(async () => {
+      value = {};
+
+      const fixtureResult = await fixture<typeof value>(value, {});
+      element = fixtureResult.element;
+      controller = fixtureResult.controller;
+
+      element.template = () => html`
+        <div id="value">${JSON.stringify(value)}</div>
+        <form ${controller.attach()}>
+          <input
+            type="string"
+            name="email"
+            @change=${controller.onChange}
+            @input=${controller.onInput}
+            @blur=${controller.onBlur}
+            .value=${controller.value.email ?? ''}>
+        </form>
+      `;
+      await element.updateComplete;
+    });
+
+    test('initialises correctly', () => {
+      const valueText =
+        element.shadowRoot!.querySelector<HTMLDivElement>('#value')!;
+      const input = element.shadowRoot!.querySelector<HTMLInputElement>(
+        'input[name="email"]'
+      )!;
+      const form = element.shadowRoot!.querySelector<HTMLFormElement>('form')!;
+
+      assert.is(valueText.textContent, JSON.stringify({}));
+      assert.is(input.value, '');
+      assert.is(controller.form, form);
+      assert.is(controller.errors.size, 0);
+      assert.is(controller.value, value);
+    });
+
+    test('reacts to change events', async () => {
+      const input = element.shadowRoot!.querySelector<HTMLInputElement>(
+        'input[name="email"]'
+      )!;
+
+      input.value = 'foo';
+      input.dispatchEvent(new Event('change'));
+      await element.updateComplete;
+
+      const valueText =
+        element.shadowRoot!.querySelector<HTMLDivElement>('#value')!;
+
+      assert.is(valueText.textContent, JSON.stringify({email: 'foo'}));
+      assert.equal(controller.value, {email: 'foo'});
+      assert.is(controller.value, value);
+    });
+
+    test('reacts to input events', async () => {
+      const input = element.shadowRoot!.querySelector<HTMLInputElement>(
+        'input[name="email"]'
+      )!;
+
+      input.value = 'foo';
+      input.dispatchEvent(new Event('input'));
+      await element.updateComplete;
+
+      const valueText =
+        element.shadowRoot!.querySelector<HTMLDivElement>('#value')!;
+
+      assert.is(valueText.textContent, JSON.stringify({email: 'foo'}));
+      assert.equal(controller.value, {email: 'foo'});
+      assert.is(controller.value, value);
+    });
+  });
+
+  suite('deep paths', () => {
+    let value: {deep?: {path?: string}};
+    let controller: FormController<typeof value>;
+
+    setup(async () => {
+      value = {};
+
+      const fixtureResult = await fixture<typeof value>(value, {});
+      element = fixtureResult.element;
+      controller = fixtureResult.controller;
+
+      element.template = () => html`
+        <div id="value">${JSON.stringify(value)}</div>
+        <form ${controller.attach()}>
+          <input
+            type="string"
+            name="deep.path"
+            @change=${controller.onChange}
+            @input=${controller.onInput}
+            @blur=${controller.onBlur}
+            .value=${controller.value.deep?.path ?? ''}>
+        </form>
+      `;
+      await element.updateComplete;
+    });
+
+    test('change sets deep path', async () => {
+      const input = element.shadowRoot!.querySelector<HTMLInputElement>(
+        'input[name="deep.path"]'
+      )!;
+
+      input.value = 'bob';
+      input.dispatchEvent(new Event('input'));
+      await element.updateComplete;
+
+      const valueText =
+        element.shadowRoot!.querySelector<HTMLDivElement>('#value')!;
+
+      assert.is(
+        valueText.textContent,
+        JSON.stringify({
+          deep: {
+            path: 'bob'
+          }
+        })
+      );
+      assert.equal(controller.value, {deep: {path: 'bob'}});
+      assert.is(controller.value, value);
+    });
+  });
+
+  suite('fields by id', () => {
+    let value: {email?: string};
+    let controller: FormController<typeof value>;
+
+    setup(async () => {
+      value = {};
+
+      const fixtureResult = await fixture<typeof value>(value, {});
+      element = fixtureResult.element;
+      controller = fixtureResult.controller;
+
+      element.template = () => html`
+        <div id="value">${JSON.stringify(value)}</div>
+        <form ${controller.attach()}>
+          <input
+            type="string"
+            id="email"
+            @change=${controller.onChange}
+            @input=${controller.onInput}
+            @blur=${controller.onBlur}
+            .value=${controller.value.email ?? ''}>
+        </form>
+      `;
+      await element.updateComplete;
+    });
+
+    test('supports id attribute', async () => {
+      const input =
+        element.shadowRoot!.querySelector<HTMLInputElement>('input#email')!;
+
+      input.value = 'foo';
+      input.dispatchEvent(new Event('input'));
+      await element.updateComplete;
+
+      const valueText =
+        element.shadowRoot!.querySelector<HTMLDivElement>('#value')!;
+
+      assert.is(valueText.textContent, JSON.stringify({email: 'foo'}));
+      assert.equal(controller.value, {email: 'foo'});
+      assert.is(controller.value, value);
+    });
+  });
+
+  test('ignores elements without identifiers', async () => {
+    const value: {email?: string} = {};
+    const fixtureResult = await fixture<typeof value>(value, {});
+    const controller = fixtureResult.controller;
+    element = fixtureResult.element;
+    element.template = () => html`
+      <div id="value">${JSON.stringify(value)}</div>
+      <form ${controller.attach()}>
+        <input
+          type="string"
+          @change=${controller.onChange}
+          @input=${controller.onInput}
+          @blur=${controller.onBlur}
+          .value=${controller.value.email ?? ''}>
+      </form>
+    `;
+    await element.updateComplete;
+
+    const input = element.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+
+    input.value = 'foo';
+    input.dispatchEvent(new Event('input'));
+    await element.updateComplete;
+
+    const valueText =
+      element.shadowRoot!.querySelector<HTMLDivElement>('#value')!;
+
+    assert.is(valueText.textContent, JSON.stringify({}));
+    assert.equal(controller.value, {});
+    assert.is(controller.value, value);
+  });
+
+  suite('immutable', () => {
+    let value: {email?: string};
+    let controller: FormController<typeof value>;
+
+    setup(async () => {
+      value = {};
+
+      const fixtureResult = await fixture<typeof value>(value, {
+        immutable: true
+      });
+      element = fixtureResult.element;
+      controller = fixtureResult.controller;
+      element.template = () => html`
+        <div id="value">${JSON.stringify(value)}</div>
+        <form ${controller.attach()}>
+          <input
+            type="string"
+            name="email"
+            @change=${controller.onChange}
+            @input=${controller.onInput}
+            @blur=${controller.onBlur}
+            .value=${controller.value.email ?? ''}>
+        </form>
+      `;
+      await element.updateComplete;
+    });
+
+    test('changes result in new value', async () => {
+      const input = element.shadowRoot!.querySelector<HTMLInputElement>(
+        'input[name="email"]'
+      )!;
+
+      const oldValue = value;
+
+      input.value = 'foo';
+      input.dispatchEvent(new Event('input'));
+      await element.updateComplete;
+
+      const newValue = controller.value;
+
+      assert.is.not(oldValue, newValue);
+      assert.equal(oldValue, {});
+      assert.equal(newValue, {email: 'foo'});
+    });
+  });
+});

--- a/src/test/controllers/form_test.ts
+++ b/src/test/controllers/form_test.ts
@@ -3,24 +3,22 @@ import '../util.js';
 import {html} from 'lit';
 import type {ReactiveController} from 'lit';
 import * as assert from 'uvu/assert';
-import {FormController, type FormControllerOptions} from '../../main.js';
+import {FormController} from '../../main.js';
 import type {TestElement} from '../util.js';
 
 /**
  * Creates a form controller fixture
  * @param {*} value Initial value
- * @param {FormControllerOptions} options Options for the controller
  * @return {Promise}
  */
 async function fixture<T extends object>(
-  value: T,
-  options: FormControllerOptions
+  value: T
 ): Promise<{
   element: TestElement;
   controller: FormController<T>;
 }> {
   const element = document.createElement('test-element') as TestElement;
-  const controller = new FormController<T>(element, value, options);
+  const controller = new FormController<T>(element, value);
   element.controllers.push(controller as ReactiveController);
   element.template = () => html`
     <div id="value">${JSON.stringify(value)}</div>
@@ -50,7 +48,7 @@ suite('FormController', () => {
     setup(async () => {
       value = {};
 
-      const fixtureResult = await fixture<typeof value>(value, {});
+      const fixtureResult = await fixture<typeof value>(value);
       element = fixtureResult.element;
       controller = fixtureResult.controller;
 
@@ -60,10 +58,7 @@ suite('FormController', () => {
           <input
             type="string"
             name="email"
-            @change=${controller.onChange}
-            @input=${controller.onInput}
-            @blur=${controller.onBlur}
-            .value=${controller.value.email ?? ''}>
+            ${controller.bind('email')}>
         </form>
       `;
       await element.updateComplete;
@@ -126,7 +121,7 @@ suite('FormController', () => {
     setup(async () => {
       value = {};
 
-      const fixtureResult = await fixture<typeof value>(value, {});
+      const fixtureResult = await fixture<typeof value>(value);
       element = fixtureResult.element;
       controller = fixtureResult.controller;
 
@@ -136,10 +131,7 @@ suite('FormController', () => {
           <input
             type="string"
             name="deep.path"
-            @change=${controller.onChange}
-            @input=${controller.onInput}
-            @blur=${controller.onBlur}
-            .value=${controller.value.deep?.path ?? ''}>
+            ${controller.bind('deep.path')}>
         </form>
       `;
       await element.updateComplete;
@@ -167,127 +159,6 @@ suite('FormController', () => {
       );
       assert.equal(controller.value, {deep: {path: 'bob'}});
       assert.is(controller.value, value);
-    });
-  });
-
-  suite('fields by id', () => {
-    let value: {email?: string};
-    let controller: FormController<typeof value>;
-
-    setup(async () => {
-      value = {};
-
-      const fixtureResult = await fixture<typeof value>(value, {});
-      element = fixtureResult.element;
-      controller = fixtureResult.controller;
-
-      element.template = () => html`
-        <div id="value">${JSON.stringify(value)}</div>
-        <form ${controller.attach()}>
-          <input
-            type="string"
-            id="email"
-            @change=${controller.onChange}
-            @input=${controller.onInput}
-            @blur=${controller.onBlur}
-            .value=${controller.value.email ?? ''}>
-        </form>
-      `;
-      await element.updateComplete;
-    });
-
-    test('supports id attribute', async () => {
-      const input =
-        element.shadowRoot!.querySelector<HTMLInputElement>('input#email')!;
-
-      input.value = 'foo';
-      input.dispatchEvent(new Event('input'));
-      await element.updateComplete;
-
-      const valueText =
-        element.shadowRoot!.querySelector<HTMLDivElement>('#value')!;
-
-      assert.is(valueText.textContent, JSON.stringify({email: 'foo'}));
-      assert.equal(controller.value, {email: 'foo'});
-      assert.is(controller.value, value);
-    });
-  });
-
-  test('ignores elements without identifiers', async () => {
-    const value: {email?: string} = {};
-    const fixtureResult = await fixture<typeof value>(value, {});
-    const controller = fixtureResult.controller;
-    element = fixtureResult.element;
-    element.template = () => html`
-      <div id="value">${JSON.stringify(value)}</div>
-      <form ${controller.attach()}>
-        <input
-          type="string"
-          @change=${controller.onChange}
-          @input=${controller.onInput}
-          @blur=${controller.onBlur}
-          .value=${controller.value.email ?? ''}>
-      </form>
-    `;
-    await element.updateComplete;
-
-    const input = element.shadowRoot!.querySelector<HTMLInputElement>('input')!;
-
-    input.value = 'foo';
-    input.dispatchEvent(new Event('input'));
-    await element.updateComplete;
-
-    const valueText =
-      element.shadowRoot!.querySelector<HTMLDivElement>('#value')!;
-
-    assert.is(valueText.textContent, JSON.stringify({}));
-    assert.equal(controller.value, {});
-    assert.is(controller.value, value);
-  });
-
-  suite('immutable', () => {
-    let value: {email?: string};
-    let controller: FormController<typeof value>;
-
-    setup(async () => {
-      value = {};
-
-      const fixtureResult = await fixture<typeof value>(value, {
-        immutable: true
-      });
-      element = fixtureResult.element;
-      controller = fixtureResult.controller;
-      element.template = () => html`
-        <div id="value">${JSON.stringify(value)}</div>
-        <form ${controller.attach()}>
-          <input
-            type="string"
-            name="email"
-            @change=${controller.onChange}
-            @input=${controller.onInput}
-            @blur=${controller.onBlur}
-            .value=${controller.value.email ?? ''}>
-        </form>
-      `;
-      await element.updateComplete;
-    });
-
-    test('changes result in new value', async () => {
-      const input = element.shadowRoot!.querySelector<HTMLInputElement>(
-        'input[name="email"]'
-      )!;
-
-      const oldValue = value;
-
-      input.value = 'foo';
-      input.dispatchEvent(new Event('input'));
-      await element.updateComplete;
-
-      const newValue = controller.value;
-
-      assert.is.not(oldValue, newValue);
-      assert.equal(oldValue, {});
-      assert.equal(newValue, {email: 'foo'});
     });
   });
 });

--- a/src/test/directives/bindInput_test.ts
+++ b/src/test/directives/bindInput_test.ts
@@ -227,7 +227,7 @@ suite('bindInput directive', () => {
 
     setup(async () => {
       valid = true;
-      const validate = () => valid;
+      const validate = (): boolean => valid;
       element.template = () => html`
         <input ${bindInput(element, 'prop', {validate})}>
       `;

--- a/src/test/directives/bindInput_test.ts
+++ b/src/test/directives/bindInput_test.ts
@@ -105,6 +105,20 @@ suite('bindInput directive', () => {
 
       assert.is(input.value, 'undefined');
     });
+
+    test('handles deep properties', async () => {
+      element.template = () => html`
+        <input ${bindInput(element, 'prop.foo')}>
+      `;
+      await element.updateComplete;
+
+      element.prop = {foo: 'xyz'};
+      await element.updateComplete;
+
+      const inputNode = element.shadowRoot!.querySelector('input')!;
+
+      assert.is(inputNode.value, 'xyz');
+    });
   });
 
   suite('user input', () => {
@@ -157,6 +171,20 @@ suite('bindInput directive', () => {
       input.value = 'bar';
       input.dispatchEvent(new Event('input'));
     });
+
+    test('handles deep properties', async () => {
+      element.template = () => html`
+        <input ${bindInput(element, 'prop.foo')}>
+      `;
+      await element.updateComplete;
+
+      const input = element.shadowRoot!.querySelector('input')!;
+
+      input.value = 'bar';
+      input.dispatchEvent(new Event('input'));
+
+      assert.is((element.prop as {foo: string}).foo, 'bar');
+    });
   });
 
   suite('options.host', () => {
@@ -191,6 +219,41 @@ suite('bindInput directive', () => {
       input.dispatchEvent(new Event('input'));
 
       assert.is(updateRequestCount, 1);
+    });
+  });
+
+  suite('options.validate', () => {
+    let valid: boolean;
+
+    setup(async () => {
+      valid = true;
+      const validate = () => valid;
+      element.template = () => html`
+        <input ${bindInput(element, 'prop', {validate})}>
+      `;
+      await element.updateComplete;
+    });
+
+    test('host value does not change if invalid', async () => {
+      valid = false;
+
+      const inputNode = element.shadowRoot!.querySelector('input')!;
+
+      inputNode.value = 'xyz';
+      inputNode.dispatchEvent(new Event('input'));
+      await element.updateComplete;
+
+      assert.is(element.prop, undefined);
+    });
+
+    test('host value is updated if valid', async () => {
+      const inputNode = element.shadowRoot!.querySelector('input')!;
+
+      inputNode.value = 'xyz';
+      inputNode.dispatchEvent(new Event('input'));
+      await element.updateComplete;
+
+      assert.is(element.prop, 'xyz');
     });
   });
 

--- a/src/test/directives/bindInput_test.ts
+++ b/src/test/directives/bindInput_test.ts
@@ -73,8 +73,9 @@ suite('bindInput directive', () => {
 
   suite('host property', () => {
     test('handles non-existent properties', async () => {
+      const key = 'nonsense' as keyof BindInputDirectiveTest;
       element.template = () => html`
-        <input ${bindInput(element, 'nonsense')}>
+        <input ${bindInput(element, key)}>
       `;
       await element.updateComplete;
 
@@ -86,7 +87,7 @@ suite('bindInput directive', () => {
 
     test('handles null hosts on attribute', async () => {
       element.template = () => html`
-        <input .value=${bindInput(null, 'key')}>
+        <input .value=${bindInput(null, 'a.b')}>
       `;
       await element.updateComplete;
 
@@ -96,8 +97,9 @@ suite('bindInput directive', () => {
     });
 
     test('handles null hosts with non-string prop on attribute', async () => {
+      const key = Symbol() as unknown as 'foo.bar'; // satisfy the type system
       element.template = () => html`
-        <input .value=${bindInput(null, Symbol())}>
+        <input .value=${bindInput(null, key)}>
       `;
       await element.updateComplete;
 
@@ -123,8 +125,9 @@ suite('bindInput directive', () => {
 
   suite('user input', () => {
     test('handles non-existent properties', async () => {
+      const key = 'nonsense' as keyof BindInputDirectiveTest;
       element.template = () => html`
-        <input ${bindInput(element, 'nonsense')}>
+        <input ${bindInput(element, key)}>
       `;
       await element.updateComplete;
 
@@ -162,7 +165,7 @@ suite('bindInput directive', () => {
 
     test('handles null hosts', async () => {
       element.template = () => html`
-        <input ${bindInput(null, 'key')}>
+        <input ${bindInput(null, 'a.b')}>
       `;
       await element.updateComplete;
 

--- a/src/types/dlv.ts
+++ b/src/types/dlv.ts
@@ -1,0 +1,7 @@
+declare module 'dlv' {
+  export default function dlv(
+    obj: unknown,
+    key: string,
+    defaultValue?: unknown
+  ): unknown;
+}

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -6,7 +6,7 @@ export default {
   files: ['src/**/*_test.ts'],
   coverage: true,
   coverageConfig: {
-    reporters: ['lcov']
+    reporters: ['html', 'lcov']
   },
   browsers: [
     puppeteerLauncher()


### PR DESCRIPTION
playing around with introducing a form controller.

with this kind of usage:

```ts
const initialValue = {foo: 'bar'};
const ctrl = new FormController(this, initialValue);

html`
  <form ${ctrl.attach()}>
    <label>
      Email:
      <input ${ctrl.bind('email')}>
    </label>
    <label>
      Password:
      <input type="password" ${ctrl.bind('password')}>
    </label>
  </form>
`;
```

you can also use validators:

* form validators run on submission _after_ user input has updated the model
* field validators run on user input _before_ user input updates the model (and can prevent it)

```ts
ctrl.addValidator((values) => {
  // values here is `ctrl.value`
  // this will be called on submission and decide if the form should submit or not
});

ctrl.addValidator(('email', (value) => {
  // value here is the email from `ctrll.value.email`
  // returning a string here will imply the field is invalid and will add the string to `ctrl.errors`
  // returning void or null will imply the field is valid
});
```

draft until it becomes less of an endless _what if?_