### PR TITLE
fix (bindInput): remove listeners from old element

### DIFF
--- a/src/directives/bindInput.ts
+++ b/src/directives/bindInput.ts
@@ -176,7 +176,7 @@ class BindInputDirective extends AsyncDirective {
    */
   private __setElement(element: Element): void {
     if (this.__element) {
-      this.__removeListenersFromElement(element);
+      this.__removeListenersFromElement(this.__element);
     }
 
     this.__element = element;


### PR DESCRIPTION
good catch by @tbroyer 

basically remove the listeners from the previous element rather than the current one