### PR TITLE
feat (enumProperty): new decorator

### DIFF
--- a/docs/enumProperty.md
+++ b/docs/enumProperty.md
@@ -1,0 +1,67 @@
+# enumProperty
+
+`enumProperty` allows you to constrain an observable property to a set of
+values.
+
+## Usage
+
+```ts
+class MyElement extends LitElement {
+  @enumProperty({
+    values: ['foo', 'bar']
+  });
+  public value?: string;
+
+  render() {
+    return html`
+      Value is: ${this.value}
+    `;
+  }
+}
+```
+
+In the above example, when `value` is set to something other than the allowed
+values, it will be set back to `undefined`.
+
+## Options
+
+### Lit options
+
+You may specify options to pass to Lit via a second argument:
+
+```ts
+@enumProperty({
+  values: ['a', 'b']
+}, {
+  state: true
+});
+```
+
+### `values`
+
+`values` is a required property in the options object and specifies the valid
+values for this property.
+
+```ts
+@enumProperty({
+  values: ['a', 'b']
+});
+```
+
+### `defaultValue`
+
+`defaultValue` can be set to specify what the default value should be when
+an invalid value has been set.
+
+For example:
+
+```ts
+@enumProperty({
+  values: ['a', 'b'],
+  defaultValue: 'a'
+});
+public value: string;
+```
+
+In this example, setting `value` to an invalid value will result in it being
+set to `a`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ The following is the full list of available utilities:
 - [documentVisibility](./documentVisibility.md) - observable [document.visibilityState](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState)
 - [elementSize](./elementSize.md) - element width and height
 - [elementVisibility](./elementVisibility.md) - element visibility
+- [enumProperty](./enumProperty.md) - enum property
 - [head](./head.md) - `<head>` tag management
 - [itemSelection](./itemSelection.md) - manages selection within an array of items
 - [keyBinding](./keyBinding.md) - key bindings (shortcuts) manager

--- a/src/decorators/enumProperty.ts
+++ b/src/decorators/enumProperty.ts
@@ -1,0 +1,62 @@
+import {PropertyDeclaration, ReactiveElement} from 'lit';
+
+export interface EnumOptions<T> {
+  defaultValue?: T;
+  values: T[];
+}
+
+/**
+ * Legacy version of the enum property decorator
+ * @param {unknown} proto Prototype to decorate
+ * @param {string} name Property to decorate
+ * @param {EnumOptions} options Options to control allowed values
+ * @param {PropertyDeclaration=} litOptions Property options for lit
+ * @return {void}
+ */
+function legacyEnumProperty<T>(
+  proto: object,
+  name: PropertyKey,
+  options: EnumOptions<T>,
+  litOptions?: PropertyDeclaration
+): void {
+  const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
+
+  Object.defineProperty(proto.constructor.prototype, name, {
+    get(): T {
+      return (this as {[key: PropertyKey]: unknown})[key] as T;
+    },
+    set(this: ReactiveElement, value: unknown) {
+      const validatedValue = options.values.includes(value as T)
+        ? value
+        : options.defaultValue;
+      const oldValue = (this as unknown as {[key: PropertyKey]: unknown})[name];
+      (this as unknown as {[key: PropertyKey]: unknown})[key] = validatedValue;
+      (this as unknown as ReactiveElement).requestUpdate(name, oldValue, {
+        ...litOptions,
+        noAccessor: true
+      });
+    },
+    configurable: true,
+    enumerable: true
+  });
+  (proto.constructor as typeof ReactiveElement).createProperty(name, {
+    ...litOptions,
+    noAccessor: true
+  });
+}
+
+/**
+ * A property decorator which enforces selection from an enumeration of
+ * possible values.
+ *
+ * @param {EnumOptions} options Options to control allowed values
+ * @param {PropertyDeclaration=} litOptions Property options for lit
+ * @return {unknown}
+ */
+export function enumProperty<T>(
+  options: EnumOptions<T>,
+  litOptions?: PropertyDeclaration
+) {
+  return (protoOrDescriptor: object, name: PropertyKey): void =>
+    legacyEnumProperty(protoOrDescriptor as object, name, options, litOptions);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,3 +13,4 @@ export * from './controllers/sessionStorage.js';
 export * from './controllers/slot.js';
 export * from './controllers/windowScroll.js';
 export * from './directives/bindInput.js';
+export * from './decorators/enumProperty.js';

--- a/src/test/decorators/enumProperty_test.ts
+++ b/src/test/decorators/enumProperty_test.ts
@@ -1,0 +1,129 @@
+import {html} from 'lit';
+import * as assert from 'uvu/assert';
+import {enumProperty} from '../../main.js';
+import {TestElementBase} from '../util.js';
+
+/**
+ * Basic test case
+ */
+class BasicEnumElement extends TestElementBase {
+  @enumProperty({
+    values: ['foo', 'bar']
+  })
+  public foo?: string;
+}
+
+customElements.define('basic-enum-test', BasicEnumElement);
+
+/**
+ * With default
+ */
+class DefaultValueEnumElement extends TestElementBase {
+  @enumProperty({
+    values: ['foo', 'bar'],
+    defaultValue: 'foo'
+  })
+  public foo?: string;
+}
+
+customElements.define('default-value-enum-test', DefaultValueEnumElement);
+
+/**
+ * With lit options
+ */
+class LitEnumElement extends TestElementBase {
+  @enumProperty(
+    {
+      values: ['foo', 'bar']
+    },
+    {
+      attribute: 'foo-foo'
+    }
+  )
+  public foo?: string;
+}
+
+customElements.define('lit-enum-test', LitEnumElement);
+
+suite('enumProperty decorator', () => {
+  suite('basic', () => {
+    let element: BasicEnumElement;
+
+    setup(async () => {
+      element = document.createElement('basic-enum-test') as BasicEnumElement;
+      element.template = () => html`${element.foo}`;
+      document.body.appendChild(element);
+      await element.updateComplete;
+    });
+
+    teardown(() => {
+      element.remove();
+    });
+
+    test('renders valid value', async () => {
+      assert.is(element.shadowRoot!.textContent, '');
+
+      element.foo = 'foo';
+      await element.updateComplete;
+
+      assert.is(element.shadowRoot!.textContent, 'foo');
+      assert.is(element.foo, 'foo');
+    });
+
+    test('clears when invalid', async () => {
+      element.foo = 'nonsense';
+      await element.updateComplete;
+
+      assert.is(element.shadowRoot!.textContent, '');
+      assert.is(element.foo, undefined);
+    });
+  });
+
+  suite('with default value', () => {
+    let element: DefaultValueEnumElement;
+
+    setup(async () => {
+      element = document.createElement(
+        'default-value-enum-test'
+      ) as DefaultValueEnumElement;
+      element.template = () => html`${element.foo}`;
+      document.body.appendChild(element);
+      await element.updateComplete;
+    });
+
+    teardown(() => {
+      element.remove();
+    });
+
+    test('renders default value when invalid', async () => {
+      element.foo = 'nonsense';
+      await element.updateComplete;
+
+      assert.is(element.shadowRoot!.textContent, 'foo');
+      assert.is(element.foo, 'foo');
+    });
+  });
+
+  suite('with lit options', () => {
+    let element: LitEnumElement;
+
+    setup(async () => {
+      element = document.createElement('lit-enum-test') as LitEnumElement;
+      element.template = () => html`${element.foo}`;
+      document.body.appendChild(element);
+      await element.updateComplete;
+    });
+
+    teardown(() => {
+      element.remove();
+    });
+
+    test('respects lit options', async () => {
+      element.setAttribute('foo-foo', 'bar');
+      await element.updateComplete;
+
+      assert.is(element.shadowRoot!.textContent, 'bar');
+      assert.is(element.foo, 'bar');
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "noUnusedParameters": true,
     "exactOptionalPropertyTypes": true,
     "noImplicitReturns": true,
+    "experimentalDecorators": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
The `enumProperty` decorator can be used as a drop-in replacement for the built-in `property` decorator but with an enum constraint enforced.

For example:

```ts
@enumProperty({
  values: ['a', 'b']
})
public value?: string;
```

In this example, `value` can only be set to `a` or `b` and will be reset to `undefined` otherwise.