### PR TITLE
fix: disable automatic type inclusion

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "./lib",
     "importHelpers": true,
     "forceConsistentCasingInFileNames": true,
+    "types": ["mocha"],
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Same old problems caused by `@types/node` being pulled in from a deep dependency and polluting the global namespace.

better to just explicitly choose which types packages we want to use