### PR TITLE
fix(bindInput): convert numbers for input[type=number]

### DIFF
--- a/src/directives/bindInput.ts
+++ b/src/directives/bindInput.ts
@@ -165,6 +165,10 @@ class BindInputDirective extends AsyncDirective {
           element.checked = value === true;
           break;
         case 'number':
+        case 'date':
+        case 'time':
+          element.valueAsNumber = value as number;
+          break;
         case 'textarea':
         default:
           element.value = String(value ?? '');
@@ -247,7 +251,9 @@ class BindInputDirective extends AsyncDirective {
           value = element.checked === true;
           break;
         case 'number':
-          value = Number(element.value);
+        case 'date':
+        case 'time':
+          value = element.valueAsNumber;
           break;
         case 'textarea':
         default:

--- a/src/test/directives/bindInput_test.ts
+++ b/src/test/directives/bindInput_test.ts
@@ -270,6 +270,7 @@ suite('bindInput directive', () => {
       const node = element.shadowRoot!.querySelector('select')!;
       const opts = [...node.selectedOptions].map((opt) => opt.value);
 
+      assert.is(node.type, 'select-multiple');
       assert.is(opts.length, 2);
       assert.equal(opts, ['808', '303']);
     });


### PR DESCRIPTION
I also rearranged the code responsible for checking the `type` so it will work better with custom elements, for instance `<md-outlined-text-field type="number">...` will naturally work  now and not just for `<input type="number">`

All tests passed 100%